### PR TITLE
fix/render-data-import-backwards-compatibility

### DIFF
--- a/Source/AGXUnreal/AGXUnreal.Build.cs
+++ b/Source/AGXUnreal/AGXUnreal.Build.cs
@@ -119,7 +119,7 @@ public class AGXUnreal : ModuleRules
 	/// Return the path to the AGXUnreal subdirectory in the Plugins directory.
 	private string GetPluginRootPath()
 	{
-		// ModuelDirectory is the full path to Plugins/AGXUnreal/Source/AGXUnreal.
+		// ModuleDirectory is the full path to Plugins/AGXUnreal/Source/AGXUnreal.
 		return Path.GetFullPath(Path.Combine(ModuleDirectory, "..", ".."));
 	}
 
@@ -244,7 +244,7 @@ public class AGXUnreal : ModuleRules
 		{
 			return;
 		}
-		if (!GetRemoteResult.Output.Contains("algoryx/unreal/agxunreal.git"))
+		if (!GetRemoteResult.Output.Contains("github.com/Algoryx/AGXUnreal.git"))
 		{
 			// Not in an AGX Dynamics for Unreal working copy.
 			return;

--- a/Source/AGXUnreal/Private/AGX_ModelSourceComponent.cpp
+++ b/Source/AGXUnreal/Private/AGX_ModelSourceComponent.cpp
@@ -1,0 +1,62 @@
+// Copyright 2024, Algoryx Simulation AB.
+
+#include "AGX_ModelSourceComponent.h"
+
+// AGX Dynamics for Unreal includes.
+#include "AGX_CustomVersion.h"
+#include "AGX_LogCategory.h"
+#include "Shapes/AGX_ShapeComponent.h"
+#include "Utilities/AGX_BlueprintUtilities.h"
+#include "Utilities/AGX_StringUtilities.h"
+
+// Unreal Engine includes.
+#include "Serialization/Archive.h"
+
+#define LOCTEXT_NAMESPACE "UAGX_ModelSourceComponent"
+
+void UAGX_ModelSourceComponent::Serialize(FArchive& Archive)
+{
+	Super::Serialize(Archive);
+
+	Archive.UsingCustomVersion(FAGX_CustomVersion::GUID);
+	if (Archive.IsLoading() &&
+		Archive.CustomVer(FAGX_CustomVersion::GUID) < FAGX_CustomVersion::RenderDataPerShape)
+	{
+		UE_LOG(LogAGX, Warning, TEXT("Reading Model Source Component from old serialization."));
+		AActor* Owner = GetOwner();
+		UBlueprint* Blueprint = FAGX_BlueprintUtilities::GetBlueprintFrom(*this);
+		UE_LOG(LogAGX, Warning, TEXT("  Owner: %s (%p)"), *GetLabelSafe(Owner), Owner);
+		UE_LOG(LogAGX, Warning, TEXT("  Blueprint: %s (%p)"), *GetNameSafe(Blueprint), Blueprint);
+		for (const auto& [Name, RenderDataGuid] : StaticMeshComponentToOwningRenderData_DEPRECATED)
+		{
+			FAGX_BlueprintUtilities::FAGX_BlueprintNodeSearchResult SearchResult =
+				FAGX_BlueprintUtilities::GetSCSNodeFromName(*Blueprint, Name, true);
+			UActorComponent* Component = SearchResult.FoundNode->ComponentTemplate;
+			UE_LOG(
+				LogAGX, Warning,
+				TEXT("  Found Render Data Static Mesh Component %s for name key %s."),
+				*GetNameSafe(Component), *Name);
+
+			USCS_Node* ShapeNode = FAGX_BlueprintUtilities::GetParentSCSNode<UAGX_ShapeComponent>(
+				SearchResult.FoundNode);
+			UAGX_ShapeComponent* ShapeComponent =
+				Cast<UAGX_ShapeComponent>(ShapeNode->ComponentTemplate);
+			FGuid ShapeGuid = ShapeComponent->ImportGuid;
+			UE_LOG(
+				LogAGX, Warning, TEXT("  Found Shape Component %s."), *GetNameSafe(ShapeComponent));
+
+			StaticMeshComponentToOwningShape.Add(Name, ShapeGuid);
+		}
+
+		if (!Blueprint->MarkPackageDirty())
+		{
+			UE_LOG(
+				LogAGX, Warning,
+				TEXT("Could not mark Blueprint package dirty after Render Data table update in "
+					 "Model Source Component."));
+		}
+	}
+
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/AGXUnreal/Private/AGX_ModelSourceComponent.cpp
+++ b/Source/AGXUnreal/Private/AGX_ModelSourceComponent.cpp
@@ -84,7 +84,7 @@ void UAGX_ModelSourceComponent::UpgradeRenderDataTableFromRenderDataUuidToShapeU
 #endif
 }
 
-const TMap<FString, FGuid> UAGX_ModelSourceComponent::GetDeprecatedRenderDataTable() const
+const TMap<FString, FGuid>& UAGX_ModelSourceComponent::GetDeprecatedRenderDataTable() const
 {
 	return StaticMeshComponentToOwningRenderData_DEPRECATED;
 }

--- a/Source/AGXUnreal/Private/AGX_ModelSourceComponent.cpp
+++ b/Source/AGXUnreal/Private/AGX_ModelSourceComponent.cpp
@@ -16,12 +16,14 @@ void UAGX_ModelSourceComponent::Serialize(FArchive& Archive)
 {
 	Super::Serialize(Archive);
 
+#if WITH_EDITOR
 	Archive.UsingCustomVersion(FAGX_CustomVersion::GUID);
 	if (Archive.IsLoading() &&
 		Archive.CustomVer(FAGX_CustomVersion::GUID) < FAGX_CustomVersion::RenderDataPerShape)
 	{
 		UpgradeRenderDataTableFromRenderDataUuidToShapeUuid();
 	}
+#endif
 }
 
 

--- a/Source/AGXUnreal/Private/AGX_ModelSourceComponent.cpp
+++ b/Source/AGXUnreal/Private/AGX_ModelSourceComponent.cpp
@@ -4,10 +4,8 @@
 
 // AGX Dynamics for Unreal includes.
 #include "AGX_CustomVersion.h"
-#include "AGX_LogCategory.h"
 #include "Shapes/AGX_ShapeComponent.h"
 #include "Utilities/AGX_BlueprintUtilities.h"
-#include "Utilities/AGX_StringUtilities.h"
 
 // Unreal Engine includes.
 #include "Serialization/Archive.h"

--- a/Source/AGXUnreal/Private/AGX_ModelSourceComponent.cpp
+++ b/Source/AGXUnreal/Private/AGX_ModelSourceComponent.cpp
@@ -24,6 +24,9 @@ void UAGX_ModelSourceComponent::Serialize(FArchive& Archive)
 	}
 }
 
+
+#if WITH_EDITOR
+
 /**
  * To support importing AGX Dynamics archives where multiple Shapes share the same Render Data
  * we changed a table to contain Shape GUIDs instead of Render Data GUIDs. When opening old
@@ -83,6 +86,8 @@ void UAGX_ModelSourceComponent::UpgradeRenderDataTableFromRenderDataUuidToShapeU
 		Blueprint->MarkPackageDirty();
 #endif
 }
+
+#endif
 
 const TMap<FString, FGuid>& UAGX_ModelSourceComponent::GetDeprecatedRenderDataTable() const
 {

--- a/Source/AGXUnreal/Private/AGX_ModelSourceComponent.cpp
+++ b/Source/AGXUnreal/Private/AGX_ModelSourceComponent.cpp
@@ -86,4 +86,9 @@ void UAGX_ModelSourceComponent::Serialize(FArchive& Archive)
 	}
 }
 
+const TMap<FString, FGuid> UAGX_ModelSourceComponent::GetDeprecatedRenderDataTable() const
+{
+	return StaticMeshComponentToOwningRenderData_DEPRECATED;
+}
+
 #undef LOCTEXT_NAMESPACE

--- a/Source/AGXUnreal/Private/AGX_ModelSourceComponent.cpp
+++ b/Source/AGXUnreal/Private/AGX_ModelSourceComponent.cpp
@@ -14,64 +14,6 @@
 
 #define LOCTEXT_NAMESPACE "UAGX_ModelSourceComponent"
 
-namespace AGX_ModelSourceComponent_helpers
-{
-	/**
-	 * To support importing AGX Dynamics archives where multiple Shapes share the same Render Data
-	 * we changed a table to contain Shape GUIDs instead of Render Data GUIDs. When opening old
-	 * imported model Blueprints the old table entries must be converted into new table entries.
-	 * This is done by finding the first parent Shape Component of each Static Mesh Component that
-	 * renders Render Data and use that Shape Component's Import GUID instead of the Render Data's
-	 * GUID.
-	 */
-	void UpgradeRenderDataTable(
-		UAGX_ModelSourceComponent& ModelSource,
-		const TMap<FString, FGuid>& StaticMeshComponentToOwningRenderData_DEPRECATED,
-		TMap<FString, FGuid>& StaticMeshComponentToOwningShape)
-	{
-		// For now, we only do the table translation for Blueprints. Is there any case where the
-		// translation must be done for a regular Actor? Any other case we should consider?
-		UBlueprint* Blueprint = FAGX_BlueprintUtilities::GetBlueprintFrom(ModelSource);
-		if (Blueprint == nullptr)
-			return;
-
-		// Migrate each entry in the old table to the new table.
-		for (const auto& [StaticMeshName, RenderDataGuid] :
-			 StaticMeshComponentToOwningRenderData_DEPRECATED)
-		{
-			// Find the Static Mesh Component that renders the Render Data.
-			USCS_Node* RenderDataMeshNode =
-				FAGX_BlueprintUtilities::GetSCSNodeFromName(*Blueprint, StaticMeshName, true)
-					.FoundNode;
-			if (RenderDataMeshNode == nullptr)
-				continue;
-
-			// Find the Shape Component that owns the Render Data.
-			USCS_Node* ShapeNode =
-				FAGX_BlueprintUtilities::GetParentSCSNode<UAGX_ShapeComponent>(RenderDataMeshNode);
-			if (ShapeNode == nullptr)
-				continue;
-			UAGX_ShapeComponent* ShapeComponent =
-				Cast<UAGX_ShapeComponent>(ShapeNode->ComponentTemplate);
-			if (ShapeComponent == nullptr)
-				continue;
-
-			// Create entry in the new table.
-			FGuid ShapeGuid = ShapeComponent->ImportGuid;
-			StaticMeshComponentToOwningShape.Add(StaticMeshName, ShapeGuid);
-		}
-
-		// We would like to save the Blueprint with the updated table and to do that we need to mark
-		// it dirty. However, Unreal does not allow marking a package dirty during loading.
-		// So the old table will linger until the Blueprint is changed through some other means.
-		// Worse, the Blueprint is the hidden parent Blueprint that the user should not modify, so
-		// it likely won't be modified until the user does a model synchronization.
-#if 0
-		Blueprint->MarkPackageDirty();
-#endif
-	}
-}
-
 void UAGX_ModelSourceComponent::Serialize(FArchive& Archive)
 {
 	Super::Serialize(Archive);
@@ -80,10 +22,68 @@ void UAGX_ModelSourceComponent::Serialize(FArchive& Archive)
 	if (Archive.IsLoading() &&
 		Archive.CustomVer(FAGX_CustomVersion::GUID) < FAGX_CustomVersion::RenderDataPerShape)
 	{
-		AGX_ModelSourceComponent_helpers::UpgradeRenderDataTable(
-			*this, StaticMeshComponentToOwningRenderData_DEPRECATED,
-			StaticMeshComponentToOwningShape);
+		UpgradeRenderDataTableFromRenderDataUuidToShapeUuid();
 	}
+}
+
+/**
+ * To support importing AGX Dynamics archives where multiple Shapes share the same Render Data
+ * we changed a table to contain Shape GUIDs instead of Render Data GUIDs. When opening old
+ * imported model Blueprints the old table entries must be converted into new table entries.
+ * This is done by finding the first parent Shape Component of each Static Mesh Component that
+ * renders Render Data and use that Shape Component's Import GUID instead of the Render Data's
+ * GUID.
+ */
+void UAGX_ModelSourceComponent::UpgradeRenderDataTableFromRenderDataUuidToShapeUuid()
+{
+	// For now, we only do the table translation for Blueprints. Is there any case where the
+	// translation must be done for a regular Actor? Any other case we should consider?
+	UBlueprint* Blueprint = FAGX_BlueprintUtilities::GetBlueprintFrom(*this);
+	if (Blueprint == nullptr)
+		return;
+
+	// Migrate each entry in the old table to the new table.
+	for (const auto& [StaticMeshName, RenderDataGuid] :
+		 StaticMeshComponentToOwningRenderData_DEPRECATED)
+	{
+		// Find the Static Mesh Component that renders the Render Data.
+		//
+		// This works in Unreal Engine 5.3, but a change in how Blueprints are loaded in Unreal
+		// Engine 5.4 made it so that the SCS Node tree has not yet been constructed when Serialize
+		// is called on the Model Source Component, which means that we cannot find the Render Data
+		// Static Mesh Component SCS Node.
+		//
+		// A workaround is to call this function manually and explicitly at a later time, when the
+		// Blueprint has been fully loaded. For model synchronization this is done by the
+		// SCS Node Collection constructor.
+		USCS_Node* RenderDataMeshNode =
+			FAGX_BlueprintUtilities::GetSCSNodeFromName(*Blueprint, StaticMeshName, true).FoundNode;
+		if (RenderDataMeshNode == nullptr)
+			continue;
+
+		// Find the Shape Component that owns the Render Data.
+		USCS_Node* ShapeNode =
+			FAGX_BlueprintUtilities::GetParentSCSNode<UAGX_ShapeComponent>(RenderDataMeshNode);
+		if (ShapeNode == nullptr)
+			continue;
+		UAGX_ShapeComponent* ShapeComponent =
+			Cast<UAGX_ShapeComponent>(ShapeNode->ComponentTemplate);
+		if (ShapeComponent == nullptr)
+			continue;
+
+		// Create entry in the new table.
+		FGuid ShapeGuid = ShapeComponent->ImportGuid;
+		StaticMeshComponentToOwningShape.Add(StaticMeshName, ShapeGuid);
+	}
+
+	// We would like to save the Blueprint with the updated table and to do that we need to mark
+	// it dirty. However, Unreal does not allow marking a package dirty during loading.
+	// So the old table will linger until the Blueprint is changed through some other means.
+	// Worse, the Blueprint is the hidden parent Blueprint that the user should not modify, so
+	// it likely won't be modified until the user does a model synchronization.
+#if 0
+		Blueprint->MarkPackageDirty();
+#endif
 }
 
 const TMap<FString, FGuid> UAGX_ModelSourceComponent::GetDeprecatedRenderDataTable() const

--- a/Source/AGXUnreal/Private/Utilities/AGX_BlueprintUtilities.cpp
+++ b/Source/AGXUnreal/Private/Utilities/AGX_BlueprintUtilities.cpp
@@ -84,7 +84,7 @@ FAGX_BlueprintUtilities::FAGX_BlueprintNodeSearchResult FAGX_BlueprintUtilities:
 	if (!SearchParentBlueprints)
 	{
 		// Nothing found, we are done.
-		return FAGX_BlueprintUtilities::FAGX_BlueprintNodeSearchResult(Blueprint, nullptr);
+		return FAGX_BlueprintNodeSearchResult(Blueprint, nullptr);
 	}
 
 	// Try with the next parent Blueprint.

--- a/Source/AGXUnreal/Public/AGX_CustomVersion.h
+++ b/Source/AGXUnreal/Public/AGX_CustomVersion.h
@@ -55,6 +55,10 @@ struct AGXUNREAL_API FAGX_CustomVersion
 		// be placed relative to a Rigid Body instead of the Wire.
 		WireRouteNodeFrame,
 
+		// In Model Source Component, associate render data Static Mesh Components with a Shape
+		// instead of a Render Data since the same Render Data can be used by many Shapes.
+		RenderDataPerShape,
+
 		// <----- New versions can be added above this line. ----->
 		VersionPlusOne,
 

--- a/Source/AGXUnreal/Public/AGX_ModelSourceComponent.h
+++ b/Source/AGXUnreal/Public/AGX_ModelSourceComponent.h
@@ -48,6 +48,18 @@ public:
 
 	virtual void Serialize(FArchive& Archive) override;
 
+	/**
+	 * Upgrade entries in the deprecated Render Data table and insert the result into the Shape
+	 * UUID based Render Data Table. This is required after loading a Blueprint saved prior to the
+	 * introduction of support for Render Data being shared by many Shape Components, which was
+	 * added in AGX Dynamics for Unreal 1.14.0.
+	 *
+	 * This is done automatically by the Serialize member function, but on some Unreal Engine
+	 * versions, at least 5.4 and 5.5, this doesn't work because of limitations of Unreal Engine's
+	 * Blueprint loading implementation.
+	 */
+	void UpgradeRenderDataTableFromRenderDataUuidToShapeUuid();
+
 	const TMap<FString, FGuid> GetDeprecatedRenderDataTable() const;
 
 private:

--- a/Source/AGXUnreal/Public/AGX_ModelSourceComponent.h
+++ b/Source/AGXUnreal/Public/AGX_ModelSourceComponent.h
@@ -45,4 +45,12 @@ public:
 	// Render Material.
 	UPROPERTY(EditAnywhere, Category = "AGX Synchronize Model Info")
 	TMap<FString, FGuid> UnrealMaterialToImportGuid;
+
+	virtual void Serialize(FArchive& Archive) override;
+
+private:
+	// Key is the name of the imported Static Mesh Component's SCS Node and the value is the guid
+	// of the owning RenderData.
+	UPROPERTY()
+	TMap<FString, FGuid> StaticMeshComponentToOwningRenderData_DEPRECATED;
 };

--- a/Source/AGXUnreal/Public/AGX_ModelSourceComponent.h
+++ b/Source/AGXUnreal/Public/AGX_ModelSourceComponent.h
@@ -48,6 +48,8 @@ public:
 
 	virtual void Serialize(FArchive& Archive) override;
 
+	const TMap<FString, FGuid> GetDeprecatedRenderDataTable() const;
+
 private:
 	// Key is the name of the imported Static Mesh Component's SCS Node and the value is the guid
 	// of the owning RenderData.

--- a/Source/AGXUnreal/Public/AGX_ModelSourceComponent.h
+++ b/Source/AGXUnreal/Public/AGX_ModelSourceComponent.h
@@ -48,6 +48,7 @@ public:
 
 	virtual void Serialize(FArchive& Archive) override;
 
+#if WITH_EDITOR
 	/**
 	 * Upgrade entries in the deprecated Render Data table and insert the result into the Shape
 	 * UUID based Render Data Table. This is required after loading a Blueprint saved prior to the
@@ -59,6 +60,7 @@ public:
 	 * Blueprint loading implementation.
 	 */
 	void UpgradeRenderDataTableFromRenderDataUuidToShapeUuid();
+#endif
 
 	const TMap<FString, FGuid>& GetDeprecatedRenderDataTable() const;
 

--- a/Source/AGXUnreal/Public/AGX_ModelSourceComponent.h
+++ b/Source/AGXUnreal/Public/AGX_ModelSourceComponent.h
@@ -48,6 +48,9 @@ public:
 
 	virtual void Serialize(FArchive& Archive) override;
 
+	const TMap<FString, FGuid>& GetDeprecatedRenderDataTable() const;
+
+private:
 #if WITH_EDITOR
 	/**
 	 * Upgrade entries in the deprecated Render Data table and insert the result into the Shape
@@ -60,9 +63,10 @@ public:
 	 * Blueprint loading implementation.
 	 */
 	void UpgradeRenderDataTableFromRenderDataUuidToShapeUuid();
+
+	void OnBlueprintLoaded(UObject* LoadedObject);
 #endif
 
-	const TMap<FString, FGuid>& GetDeprecatedRenderDataTable() const;
 
 private:
 	// Key is the name of the imported Static Mesh Component's SCS Node and the value is the guid

--- a/Source/AGXUnreal/Public/AGX_ModelSourceComponent.h
+++ b/Source/AGXUnreal/Public/AGX_ModelSourceComponent.h
@@ -60,7 +60,7 @@ public:
 	 */
 	void UpgradeRenderDataTableFromRenderDataUuidToShapeUuid();
 
-	const TMap<FString, FGuid> GetDeprecatedRenderDataTable() const;
+	const TMap<FString, FGuid>& GetDeprecatedRenderDataTable() const;
 
 private:
 	// Key is the name of the imported Static Mesh Component's SCS Node and the value is the guid

--- a/Source/AGXUnreal/Public/Utilities/AGX_BlueprintUtilities.h
+++ b/Source/AGXUnreal/Public/Utilities/AGX_BlueprintUtilities.h
@@ -128,6 +128,8 @@ public:
 	 */
 	static USCS_Node* GetParentSCSNode(USCS_Node* Node, bool bSearchParentBlueprints = true);
 
+	template <typename ParentComponentT>
+	static USCS_Node* GetParentSCSNode(USCS_Node* Node, bool bSearchParentBlueprints = true);
 	/**
 	 * Finds the first parent Component that resided in the same Blueprint as the given
 	 * ComponentTemplate. This function may search in parent Blueprints for SCS Nodes, but will walk
@@ -152,6 +154,22 @@ public:
 	template <typename T>
 	static T* GetFirstComponentOfType(UBlueprint* Blueprint, bool SkipSceneRoot = false);
 };
+
+template <typename ParentComponentT>
+USCS_Node* FAGX_BlueprintUtilities::GetParentSCSNode(USCS_Node* Node, bool bSearchParentBlueprints)
+{
+	USCS_Node* It = Node;
+	while (It != nullptr)
+	{
+		USCS_Node* ParentNode = GetParentSCSNode(It, bSearchParentBlueprints);
+		if (ParentNode != nullptr && Cast<ParentComponentT>(ParentNode->ComponentTemplate) != nullptr)
+		{
+			return ParentNode;
+		}
+		It = ParentNode;
+	}
+	return nullptr;
+}
 
 template <typename T>
 T* FAGX_BlueprintUtilities::GetFirstComponentOfType(UBlueprint* Blueprint, bool SkipSceneRoot)

--- a/Source/AGXUnrealEditor/Private/AGX_ImporterToBlueprint.cpp
+++ b/Source/AGXUnrealEditor/Private/AGX_ImporterToBlueprint.cpp
@@ -1008,21 +1008,6 @@ namespace AGX_ImporterToBlueprint_SynchronizeModel_helpers
 						}
 					}
 
-					if (Re->GetDeprecatedRenderDataTable().Num() > 0)
-					{
-						// When adding support for shared Render Data, i.e. many Shape Components
-						// having Static Mesh Components pointing to the same Static Mesh asset, a
-						// table was converted from holding Render Data UUIDs to instead holding
-						// Shape UUIDs. When loading old Blueprints with data in the old table those
-						// table entries must be upgraded to the new format and moved to the new
-						// table. This is normally done in the Serialize member function, but with
-						// Unreal Engine 5.4 Epic Games changed the Blueprints are loaded caused
-						// the upgrade code to fail. It could no longer find the Static Mesh SCS
-						// Node that is needed to do the upgrade. So instead we do that work here,
-						// where the Blueprint has been completely loaded.
-						Re->UpgradeRenderDataTableFromRenderDataUuidToShapeUuid();
-					}
-
 					for (const auto& [MeshName, ShapeGuid] : Re->StaticMeshComponentToOwningShape)
 					{
 						if (!ShapeGuid.IsValid())

--- a/Source/AGXUnrealEditor/Private/AGX_ImporterToBlueprint.cpp
+++ b/Source/AGXUnrealEditor/Private/AGX_ImporterToBlueprint.cpp
@@ -1008,6 +1008,21 @@ namespace AGX_ImporterToBlueprint_SynchronizeModel_helpers
 						}
 					}
 
+					if (Re->GetDeprecatedRenderDataTable().Num() > 0)
+					{
+						// When adding support for shared Render Data, i.e. many Shape Components
+						// having Static Mesh Components pointing to the same Static Mesh asset, a
+						// table was converted from holding Render Data UUIDs to instead holding
+						// Shape UUIDs. When loading old Blueprints with data in the old table those
+						// table entries must be upgraded to the new format and moved to the new
+						// table. This is normally done in the Serialize member function, but with
+						// Unreal Engine 5.4 Epic Games changed the Blueprints are loaded caused
+						// the upgrade code to fail. It could no longer find the Static Mesh SCS
+						// Node that is needed to do the upgrade. So instead we do that work here,
+						// where the Blueprint has been completely loaded.
+						Re->UpgradeRenderDataTableFromRenderDataUuidToShapeUuid();
+					}
+
 					for (const auto& [MeshName, ShapeGuid] : Re->StaticMeshComponentToOwningShape)
 					{
 						if (!ShapeGuid.IsValid())

--- a/Source/AGXUnrealTests/Private/AGX_AssetBackwardsCompatibility.spec.cpp
+++ b/Source/AGXUnrealTests/Private/AGX_AssetBackwardsCompatibility.spec.cpp
@@ -584,7 +584,7 @@ void FAGX_ModelSourceComponentAndRenderDataBackwardsCompatibilitySpec::Define()
 
 				   // Test that the Model Source Component has entries in the old table, otherwise
 				   // this would not be an old asset.
-				   const TMap<FString, FGuid> OldTable =
+				   const TMap<FString, FGuid>& OldTable =
 					   ModelSourceComponent->GetDeprecatedRenderDataTable();
 				   if (!TestEqual(TEXT("OldTable.Num()"), OldTable.Num(), 1))
 					   return;
@@ -595,7 +595,7 @@ void FAGX_ModelSourceComponentAndRenderDataBackwardsCompatibilitySpec::Define()
 				   const FString& OldKey = OldKeys[0];
 
 				   // Make sure the new table has the entry we expect.
-				   const TMap<FString, FGuid> NewTable =
+				   const TMap<FString, FGuid>& NewTable =
 					   ModelSourceComponent->StaticMeshComponentToOwningShape;
 				   if (!TestEqual(TEXT("NewTable.Num()"), NewTable.Num(), 1))
 					   return;

--- a/Source/AGXUnrealTests/Private/AGX_AssetBackwardsCompatibility.spec.cpp
+++ b/Source/AGXUnrealTests/Private/AGX_AssetBackwardsCompatibility.spec.cpp
@@ -577,6 +577,11 @@ void FAGX_ModelSourceComponentAndRenderDataBackwardsCompatibilitySpec::Define()
 				   if (!TestNotNull(TEXT("ModelSourceComponent"), ModelSourceComponent))
 					   return;
 
+				   // Due to a bug introduced with Unreal Engine 5.4 we must manually upgrade the
+				   // Render Data tables since Serialize doesn't work properly after Unreal
+				   // Engine 5.3.
+				   ModelSourceComponent->UpgradeRenderDataTableFromRenderDataUuidToShapeUuid();
+
 				   // Test that the Model Source Component has entries in the old table, otherwise
 				   // this would not be an old asset.
 				   const TMap<FString, FGuid> OldTable =

--- a/Source/AGXUnrealTests/Private/AGX_AssetBackwardsCompatibility.spec.cpp
+++ b/Source/AGXUnrealTests/Private/AGX_AssetBackwardsCompatibility.spec.cpp
@@ -525,29 +525,32 @@ void FAGX_ModelSourceComponentAndRenderDataBackwardsCompatibilitySpec::Define()
 			It("should migrate Static Mesh Component table entries",
 			   [this]()
 			   {
+				   auto MakePath = [](const TCHAR* Asset) -> FString {
+					   return FString::Printf(
+						   TEXT("/Game/Tests/BackwardsCompatibility/render_data_build/%s"), Asset);
+				   };
+
 				   // Make sure the imported assets hasn't been accidentally saved-over since the
 				   // import on AGX Dynamics for Unreal 1.13.1.
 
 				   // Base Blueprint.
 				   const FString PackagePathBpBase {
-					   TEXT("/Game/Tests/BackwardsCompatibility/render_data_build/Blueprint/"
-							"BP_Base_1FE6507766DD477192D85058E3CDAB4B")};
+					   MakePath(TEXT("Blueprint/"
+									 "BP_Base_1FE6507766DD477192D85058E3CDAB4B"))};
 				   const FString MD5ChecksumBpBase {TEXT("21236f5cc49bbff1e853ac359a0036e8")};
 				   AgxAutomationCommon::CheckAssetMD5Checksum(
 					   PackagePathBpBase, *MD5ChecksumBpBase, *this);
 
 				   // Child Blueprint.
-				   const FString PackagePathBpChild {
-					   TEXT("/Game/Tests/BackwardsCompatibility/render_data_build/"
-							"BP_render_data_build")};
+				   const FString PackagePathBpChild {MakePath(TEXT("BP_render_data_build"))};
 				   const FString MD5ChecksumBpChild {TEXT("4fe8226fa70940a9a234735444c15dd8")};
 				   AgxAutomationCommon::CheckAssetMD5Checksum(
 					   PackagePathBpChild, *MD5ChecksumBpChild, *this);
 
 				   // Static Mesh.
 				   const FString PackagePathMesh {
-					   TEXT("/Game/Tests/BackwardsCompatibility/render_data_build/RenderMesh/"
-							"SM_RenderMesh_944C2AF4E9279E2C61D073B86467F6BA")};
+					   MakePath(TEXT("RenderMesh/"
+									 "SM_RenderMesh_944C2AF4E9279E2C61D073B86467F6BA"))};
 				   const FString MD5ChecksumMesh {TEXT("17c060944fc0aae17354671846bceb32")};
 				   AgxAutomationCommon::CheckAssetMD5Checksum(
 					   PackagePathMesh, *MD5ChecksumMesh, *this);

--- a/Source/AGXUnrealTests/Private/AGX_AssetBackwardsCompatibility.spec.cpp
+++ b/Source/AGXUnrealTests/Private/AGX_AssetBackwardsCompatibility.spec.cpp
@@ -538,65 +538,79 @@ void FAGX_ModelSourceComponentAndRenderDataBackwardsCompatibilitySpec::Define()
 					   MakePath(TEXT("Blueprint/"
 									 "BP_Base_1FE6507766DD477192D85058E3CDAB4B"))};
 				   const FString MD5ChecksumBpBase {TEXT("21236f5cc49bbff1e853ac359a0036e8")};
-				   AgxAutomationCommon::CheckAssetMD5Checksum(
-					   PackagePathBpBase, *MD5ChecksumBpBase, *this);
+				   if (!AgxAutomationCommon::CheckAssetMD5Checksum(
+						   PackagePathBpBase, *MD5ChecksumBpBase, *this))
+					   return;
 
 				   // Child Blueprint.
 				   const FString PackagePathBpChild {MakePath(TEXT("BP_render_data_build"))};
 				   const FString MD5ChecksumBpChild {TEXT("4fe8226fa70940a9a234735444c15dd8")};
-				   AgxAutomationCommon::CheckAssetMD5Checksum(
-					   PackagePathBpChild, *MD5ChecksumBpChild, *this);
+				   if (!AgxAutomationCommon::CheckAssetMD5Checksum(
+						   PackagePathBpChild, *MD5ChecksumBpChild, *this))
+					   return;
 
 				   // Static Mesh.
 				   const FString PackagePathMesh {
 					   MakePath(TEXT("RenderMesh/"
 									 "SM_RenderMesh_944C2AF4E9279E2C61D073B86467F6BA"))};
 				   const FString MD5ChecksumMesh {TEXT("17c060944fc0aae17354671846bceb32")};
-				   AgxAutomationCommon::CheckAssetMD5Checksum(
-					   PackagePathMesh, *MD5ChecksumMesh, *this);
+				   if (!AgxAutomationCommon::CheckAssetMD5Checksum(
+						   PackagePathMesh, *MD5ChecksumMesh, *this))
+					   return;
 
 				   // Load the base Blueprint.
 				   UBlueprint* BaseBlueprint = LoadAsset<UBlueprint>(
 					   PackagePathBpBase, "BP_Base_1FE6507766DD477192D85058E3CDAB4B");
-				   TestNotNull(TEXT("BaseBlueprint"), BaseBlueprint);
+				   if (!TestNotNull(TEXT("BaseBlueprint"), BaseBlueprint))
+					   return;
 
 				   // Get the SCS Node for the Model Source Component.
 				   USCS_Node* ModelSourceNode = FAGX_BlueprintUtilities::GetSCSNodeFromName(
 													*BaseBlueprint, TEXT("AGX_ModelSource"), true)
 													.FoundNode;
-				   TestNotNull(TEXT("ModelSourceNode"), ModelSourceNode);
+				   if (!TestNotNull(TEXT("ModelSourceNode"), ModelSourceNode))
+					   return;
 
 				   // Get the Model Source Component.
 				   UAGX_ModelSourceComponent* ModelSourceComponent =
 					   Cast<UAGX_ModelSourceComponent>(ModelSourceNode->ComponentTemplate);
-				   TestNotNull(TEXT("ModelSourceComponent"), ModelSourceComponent);
+				   if (!TestNotNull(TEXT("ModelSourceComponent"), ModelSourceComponent))
+					   return;
 
 				   // Test that the Model Source Component has entries in the old table, otherwise
 				   // this would not be an old asset.
 				   const TMap<FString, FGuid> OldTable =
 					   ModelSourceComponent->GetDeprecatedRenderDataTable();
-				   TestEqual(TEXT("OldTable.Num()"), OldTable.Num(), 1);
+				   if (!TestEqual(TEXT("OldTable.Num()"), OldTable.Num(), 1))
+					   return;
 				   TArray<FString> OldKeys;
 				   OldTable.GetKeys(OldKeys);
-				   TestEqual(TEXT("OldKeys.Num()"), OldKeys.Num(), 1);
+				   if (!TestEqual(TEXT("OldKeys.Num()"), OldKeys.Num(), 1))
+					   return;
 				   const FString& OldKey = OldKeys[0];
 
 				   // Make sure the new table has the entry we expect.
 				   const TMap<FString, FGuid> NewTable =
 					   ModelSourceComponent->StaticMeshComponentToOwningShape;
-				   TestEqual(TEXT("NewTable.Num()"), NewTable.Num(), 1);
+				   if (!TestEqual(TEXT("NewTable.Num()"), NewTable.Num(), 1))
+					   return;
 				   TArray<FString> NewKeys;
 				   ModelSourceComponent->StaticMeshComponentToOwningShape.GetKeys(NewKeys);
-				   TestEqual(TEXT("NewKeys.Num()"), NewKeys.Num(), 1);
+				   if (!TestEqual(TEXT("NewKeys.Num()"), NewKeys.Num(), 1))
+					   return;
 				   const FString& NewKey = NewKeys[0];
 				   const FString ExpectedKey {TEXT("RenderMesh_944C2AF4E9279E2C61D073B86467F6BA")};
-				   TestEqual(TEXT("NewKey, literal"), NewKey, ExpectedKey);
-				   TestEqual(TEXT("NewKey, OldKey"), NewKey, OldKey);
+				   if (!TestEqual(TEXT("NewKey, literal"), NewKey, ExpectedKey))
+					   return;
+				   if (!TestEqual(TEXT("NewKey, OldKey"), NewKey, OldKey))
+					   return;
 				   const FGuid Guid =
 					   ModelSourceComponent->StaticMeshComponentToOwningShape[NewKey];
 				   const FString ExpectedGuid {TEXT("D44C9070-444A-F0CA-F233-6CC3F8526D95")};
-				   TestEqual(
-					   TEXT("Guid"), Guid.ToString(EGuidFormats::DigitsWithHyphens), ExpectedGuid);
+				   if (!TestEqual(
+						   TEXT("Guid"), Guid.ToString(EGuidFormats::DigitsWithHyphens),
+						   ExpectedGuid))
+					   return;
 			   });
 		});
 }

--- a/Source/AGXUnrealTests/Private/AGX_AssetBackwardsCompatibility.spec.cpp
+++ b/Source/AGXUnrealTests/Private/AGX_AssetBackwardsCompatibility.spec.cpp
@@ -577,11 +577,6 @@ void FAGX_ModelSourceComponentAndRenderDataBackwardsCompatibilitySpec::Define()
 				   if (!TestNotNull(TEXT("ModelSourceComponent"), ModelSourceComponent))
 					   return;
 
-				   // Due to a bug introduced with Unreal Engine 5.4 we must manually upgrade the
-				   // Render Data tables since Serialize doesn't work properly after Unreal
-				   // Engine 5.3.
-				   ModelSourceComponent->UpgradeRenderDataTableFromRenderDataUuidToShapeUuid();
-
 				   // Test that the Model Source Component has entries in the old table, otherwise
 				   // this would not be an old asset.
 				   const TMap<FString, FGuid>& OldTable =


### PR DESCRIPTION
In order to support model synchronization of Blueprints imported before the shared render data fix we need to convert entries in the old render data table into entries in the new render data table on serialization load.