### PR TITLE
fix/crash-after-destroy-rigidbody

### DIFF
--- a/Source/AGXUnreal/Private/AGX_RigidBodyComponent.cpp
+++ b/Source/AGXUnreal/Private/AGX_RigidBodyComponent.cpp
@@ -599,7 +599,6 @@ bool UAGX_RigidBodyComponent::ReadTransformFromNative()
 		MoveComponent(LocationDelta, NewRotation, false);
 		if (!HasNative())
 		{
-			UE_LOG(LogAGX, Warning, TEXT("TransformSelf detected Component destruction."));
 			return true;
 		}
 		ComponentVelocity = NativeBarrier.GetVelocity();

--- a/Source/AGXUnreal/Private/AGX_RigidBodyComponent.cpp
+++ b/Source/AGXUnreal/Private/AGX_RigidBodyComponent.cpp
@@ -597,11 +597,10 @@ bool UAGX_RigidBodyComponent::ReadTransformFromNative()
 		// MoveComponent may trigger user callbacks, e.g. On Begin Overlap, which may remove this
 		// Rigid Body from the simulation.
 		MoveComponent(LocationDelta, NewRotation, false);
-		if (!HasNative())
+		if (HasNative())
 		{
-			return true;
+			ComponentVelocity = NativeBarrier.GetVelocity();
 		}
-		ComponentVelocity = NativeBarrier.GetVelocity();
 		return true;
 	};
 

--- a/Source/AGXUnreal/Private/AGX_RigidBodyComponent.cpp
+++ b/Source/AGXUnreal/Private/AGX_RigidBodyComponent.cpp
@@ -311,9 +311,14 @@ void UAGX_RigidBodyComponent::TickComponent(
 	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
 	if (MotionControl != MC_STATIC)
 	{
+		// ReadTransformFromNative may trigger user callbacks, e.g. On Begin Overlap, which may
+		// destroy this Component.
 		ReadTransformFromNative();
-		Velocity = NativeBarrier.GetVelocity();
-		AngularVelocity = NativeBarrier.GetAngularVelocity();
+		if (HasNative())
+		{
+			Velocity = NativeBarrier.GetVelocity();
+			AngularVelocity = NativeBarrier.GetAngularVelocity();
+		}
 	}
 }
 
@@ -589,7 +594,14 @@ bool UAGX_RigidBodyComponent::ReadTransformFromNative()
 	{
 		const FVector OldLocation = GetComponentLocation();
 		const FVector LocationDelta = NewLocation - OldLocation;
+		// MoveComponent may trigger user callbacks, e.g. On Begin Overlap, which may destroy this
+		// Component.
 		MoveComponent(LocationDelta, NewRotation, false);
+		if (!HasNative())
+		{
+			UE_LOG(LogAGX, Warning, TEXT("TransformSelf detected Component destruction."));
+			return true;
+		}
 		ComponentVelocity = NativeBarrier.GetVelocity();
 		return true;
 	};
@@ -613,8 +625,13 @@ bool UAGX_RigidBodyComponent::ReadTransformFromNative()
 		FTransform::Multiply(&NewTransform, &AncestorRelativeToBody, &TargetBodyLocation);
 		NewTransform.SetScale3D(Ancestor.GetComponentScale());
 
+		// SetWorldTransform may trigger user callbacks, e.g. On Begin Overlap, which may destroy
+		// this Component.
 		Ancestor.SetWorldTransform(NewTransform);
-		Ancestor.ComponentVelocity = NativeBarrier.GetVelocity();
+		if (HasNative())
+		{
+			Ancestor.ComponentVelocity = NativeBarrier.GetVelocity();
+		}
 	};
 
 	auto TryTransformAncestor =

--- a/Source/AGXUnreal/Private/AGX_RigidBodyComponent.cpp
+++ b/Source/AGXUnreal/Private/AGX_RigidBodyComponent.cpp
@@ -312,7 +312,7 @@ void UAGX_RigidBodyComponent::TickComponent(
 	if (MotionControl != MC_STATIC)
 	{
 		// ReadTransformFromNative may trigger user callbacks, e.g. On Begin Overlap, which may
-		// destroy this Component.
+		// remove this Rigid Body from the simulation.
 		ReadTransformFromNative();
 		if (HasNative())
 		{
@@ -594,8 +594,8 @@ bool UAGX_RigidBodyComponent::ReadTransformFromNative()
 	{
 		const FVector OldLocation = GetComponentLocation();
 		const FVector LocationDelta = NewLocation - OldLocation;
-		// MoveComponent may trigger user callbacks, e.g. On Begin Overlap, which may destroy this
-		// Component.
+		// MoveComponent may trigger user callbacks, e.g. On Begin Overlap, which may remove this
+		// Rigid Body from the simulation.
 		MoveComponent(LocationDelta, NewRotation, false);
 		if (!HasNative())
 		{
@@ -625,8 +625,8 @@ bool UAGX_RigidBodyComponent::ReadTransformFromNative()
 		FTransform::Multiply(&NewTransform, &AncestorRelativeToBody, &TargetBodyLocation);
 		NewTransform.SetScale3D(Ancestor.GetComponentScale());
 
-		// SetWorldTransform may trigger user callbacks, e.g. On Begin Overlap, which may destroy
-		// this Component.
+		// SetWorldTransform may trigger user callbacks, e.g. On Begin Overlap, which may remove
+		// this Rigid Body from the simulation.
 		Ancestor.SetWorldTransform(NewTransform);
 		if (HasNative())
 		{


### PR DESCRIPTION
Detect Rigid Body native release nested inside Tick Component, don't use the native in that case.