### PR TITLE
feature/wire-parameter-controller

### DIFF
--- a/Source/AGXUnreal/Private/Wire/AGX_WireComponent.cpp
+++ b/Source/AGXUnreal/Private/Wire/AGX_WireComponent.cpp
@@ -1467,6 +1467,7 @@ void UAGX_WireComponent::InitPropertyDispatcher()
 	ADD_PARAMETER_CONTROLLER_DISPACTCHER(RadiusMultiplier);
 	ADD_PARAMETER_CONTROLLER_DISPACTCHER(ScaleConstant);
 	ADD_PARAMETER_CONTROLLER_DISPACTCHER(SplitTensionMultiplier);
+	ADD_PARAMETER_CONTROLLER_DISPACTCHER(StopNodeLumpMinDistanceFraction);
 
 	Dispatcher.Add(
 		GET_MEMBER_NAME_CHECKED(UAGX_WireComponent, RenderMaterial),

--- a/Source/AGXUnreal/Private/Wire/AGX_WireComponent.cpp
+++ b/Source/AGXUnreal/Private/Wire/AGX_WireComponent.cpp
@@ -3,20 +3,21 @@
 #include "Wire/AGX_WireComponent.h"
 
 // AGX Dynamics for Unreal includes.
+#include "AGXUnrealBarrier.h"
 #include "AGX_LogCategory.h"
+#include "AGX_PropertyChangedDispatcher.h"
 #include "AGX_RigidBodyComponent.h"
 #include "AGX_Simulation.h"
-#include "AGX_PropertyChangedDispatcher.h"
-#include "AGXUnrealBarrier.h"
 #include "Materials/AGX_ShapeMaterial.h"
 #include "Utilities/AGX_NotificationUtilities.h"
-#include "Utilities/AGX_StringUtilities.h"
 #include "Utilities/AGX_ObjectUtilities.h"
+#include "Utilities/AGX_StringUtilities.h"
 #include "Wire/AGX_WireInstanceData.h"
 #include "Wire/AGX_WireNode.h"
 #include "Wire/AGX_WireUtilities.h"
 #include "Wire/AGX_WireWinchComponent.h"
 #include "Wire/WireNodeBarrier.h"
+#include "Wire/WireParameterControllerBarrier.h"
 
 // Unreal Engine includes.
 #include "Components/ActorComponent.h"
@@ -1295,6 +1296,7 @@ void UAGX_WireComponent::SetNativeAddress(uint64 NativeAddress)
 {
 	check(!HasNative());
 	NativeBarrier.SetNativeAddress(static_cast<uintptr_t>(NativeAddress));
+	WireParameterController.SetBarrier(NativeBarrier.GetParameterController());
 
 	if (HasNative())
 	{
@@ -1442,7 +1444,18 @@ void UAGX_WireComponent::InitPropertyDispatcher()
 
 	Dispatcher.Add(
 		GET_MEMBER_NAME_CHECKED(UAGX_WireComponent, bCanCollide),
-		[](ThisClass* Wire) { Wire->SetCanCollide(Wire->bCanCollide); });
+		[](ThisClass* This) { This->SetCanCollide(This->bCanCollide); });
+
+	Dispatcher.Add(
+		GET_MEMBER_NAME_CHECKED(UAGX_WireComponent, WireParameterController),
+		GET_MEMBER_NAME_CHECKED(FAGX_WireParameterController, ScaleConstant),
+		[](ThisClass* This)
+		{
+			if (This->HasNative())
+			{
+				This->WireParameterController.WritePropertiesToNative();
+			}
+		});
 
 	Dispatcher.Add(
 		GET_MEMBER_NAME_CHECKED(UAGX_WireComponent, RenderMaterial),
@@ -1549,13 +1562,14 @@ void UAGX_WireComponent::PreEditChange(FEditPropertyChain& PropertyAboutToChange
 {
 	UObject::PreEditChange(PropertyAboutToChange);
 
-	// Here I would like to detect if the change is about to give a routing node a new parent and if
-	// so unsubscribe from the Transform Updated event on the old parent, but I don't know how to
-	// find the index in the Route Nodes list of the routing node that is about to be given a new
-	// parent. In the PostEditChangeChainProperty callback we get a FPropertyChangedChainEvent
-	// instead of a FEditPropertyChain and the event knows the array index because it has been
-	// created from an FPropertyHandle, which has access to FPropertyNode, instead of from an
-	// FProperty. The FProperty doesn't seem to know the array index.
+	// Here I would like to detect if the change is about to give a routing node a new parent
+	// and if so unsubscribe from the Transform Updated event on the old parent, but I don't
+	// know how to find the index in the Route Nodes list of the routing node that is about to
+	// be given a new parent. In the PostEditChangeChainProperty callback we get a
+	// FPropertyChangedChainEvent instead of a FEditPropertyChain and the event knows the array
+	// index because it has been created from an FPropertyHandle, which has access to
+	// FPropertyNode, instead of from an FProperty. The FProperty doesn't seem to know the array
+	// index.
 }
 
 void UAGX_WireComponent::PostEditChangeChainProperty(FPropertyChangedChainEvent& Event)
@@ -1576,17 +1590,18 @@ void UAGX_WireComponent::PostEditChangeChainProperty(FPropertyChangedChainEvent&
 			// We have no way of knowing what the old parent was, or if the changed node was the
 			// last to have it has its parent, so the best we can do is to synchronize all node
 			// parents. We used to have an attempt at a more incremental approach here but that
-			// didn't work out because of this. To find the old implementation search the Git patch
-			// history for
+			// didn't work out because of this. To find the old implementation search the Git
+			// patch history for
 			//
-			//    Did a node get a new parent, meaning we must set up a new parent-moved callback?
+			//    Did a node get a new parent, meaning we must set up a new parent-moved
+			//    callback?
 			SynchronizeParentMovedCallbacks();
 		}
 	}
 
-	// If we are part of a Blueprint then this will trigger a RerunConstructionScript on the owning
-	// Actor. That means that this object will be removed from the Actor and destroyed. We want to
-	// apply all our changes before that so that they are carried over to the copy.
+	// If we are part of a Blueprint then this will trigger a RerunConstructionScript on the
+	// owning Actor. That means that this object will be removed from the Actor and destroyed.
+	// We want to apply all our changes before that so that they are carried over to the copy.
 	Super::PostEditChangeChainProperty(Event);
 }
 #endif
@@ -1596,9 +1611,9 @@ void UAGX_WireComponent::BeginPlay()
 	Super::BeginPlay();
 	if (!HasNative() && !GIsReconstructingBlueprintInstances)
 	{
-		// Do not create a native AGX Dynamics object if GIsReconstructingBlueprintInstances is set.
-		// That means that we're being created as part of a Blueprint Reconstruction and we will
-		// soon be assigned the native that the reconstructed Wire Component had, if any.
+		// Do not create a native AGX Dynamics object if GIsReconstructingBlueprintInstances is
+		// set. That means that we're being created as part of a Blueprint Reconstruction and we
+		// will soon be assigned the native that the reconstructed Wire Component had, if any.
 		CreateNative();
 		check(HasNative()); /// @todo Consider better error handling than check.
 
@@ -1659,6 +1674,7 @@ void UAGX_WireComponent::EndPlay(const EEndPlayReason::Type Reason)
 	if (HasNative())
 	{
 		NativeBarrier.ReleaseNative();
+		WireParameterController.SetBarrier(FWireParameterControllerBarrier());
 	}
 }
 
@@ -1674,9 +1690,9 @@ void UAGX_WireComponent::OnRegister()
 {
 	Super::OnRegister();
 
-	// During level load any Blueprint Instances will be created by running the Construction Script.
-	// Any routing nodes created by that script will not be seen by Post Init Properties and Post
-	// Load, so their Local Scope must be set here.
+	// During level load any Blueprint Instances will be created by running the Construction
+	// Script. Any routing nodes created by that script will not be seen by Post Init Properties
+	// and Post Load, so their Local Scope must be set here.
 	AGX_WireComponent_helpers::SetLocalScope(*this);
 
 #if WITH_EDITORONLY_DATA
@@ -1760,12 +1776,12 @@ namespace AGX_WireComponent_helpers
 		const FTransform& SourceTransform, const FTransform& TargetTransform,
 		const FVector& LocalLocation)
 	{
-		// A.GetRelativeTransform(B) produces a transformation that goes from B to A. That is, it
-		// tells us where A is in relation to B. Transforming the zero vector with that transform
-		// will produce the vector pointing from B to A. Transforming any other vector will produce
-		// the vector pointing from B to the tip of the first vector when placed with its base at A.
-		// In our case we want the vector pointing from TargetTransform so that should be our B,
-		// i.e. the parameter.
+		// A.GetRelativeTransform(B) produces a transformation that goes from B to A. That is,
+		// it tells us where A is in relation to B. Transforming the zero vector with that
+		// transform will produce the vector pointing from B to A. Transforming any other vector
+		// will produce the vector pointing from B to the tip of the first vector when placed
+		// with its base at A. In our case we want the vector pointing from TargetTransform so
+		// that should be our B, i.e. the parameter.
 		FTransform SourceToTarget = SourceTransform.GetRelativeTransform(TargetTransform);
 		return SourceToTarget.TransformPosition(LocalLocation);
 	}
@@ -1920,6 +1936,16 @@ namespace AGX_WireComponent_helpers
 	}
 }
 
+void UAGX_WireComponent::SetWireParameterController(const FAGX_WireParameterController& InWireParameterController)
+{
+	WireParameterController = InWireParameterController;
+	WireParameterController.SetBarrier(NativeBarrier.GetParameterController());
+	if (WireParameterController.HasNative())
+	{
+		WireParameterController.WritePropertiesToNative();
+	}
+}
+
 bool UAGX_WireComponent::SetShapeMaterial(UAGX_ShapeMaterial* InShapeMaterial)
 {
 	UAGX_ShapeMaterial* ShapeMaterialOrig = ShapeMaterial;
@@ -2013,6 +2039,7 @@ void UAGX_WireComponent::CreateNative()
 	const float ResolutionPerUnitLength = 1.0f / MinSegmentLength;
 	NativeBarrier.AllocateNative(Radius, ResolutionPerUnitLength);
 	check(HasNative()); /// @todo Consider better error handling than 'check'.
+	WireParameterController.SetBarrier(NativeBarrier.GetParameterController());
 
 	if (!UpdateNativeMaterial())
 	{
@@ -2025,9 +2052,7 @@ void UAGX_WireComponent::CreateNative()
 	NativeBarrier.SetLinearVelocityDamping(LinearVelocityDamping);
 	NativeBarrier.SetEnableCollisions(bCanCollide);
 	NativeBarrier.AddCollisionGroups(CollisionGroups);
-
-	/// @todo Not sure if we should expose Scale Constant or not.
-	// NativeBarrier.SetScaleConstant(ScaleConstant);
+	WireParameterController.WritePropertiesToNative();
 
 	const FTransform LocalToWorld = GetComponentTransform();
 
@@ -2068,7 +2093,8 @@ void UAGX_WireComponent::CreateNative()
 				if (Body == nullptr)
 				{
 					ErrorMessages.Add(FString::Printf(
-						TEXT("Wire node at index %d has invalid body. Creating Free Node instead "
+						TEXT("Wire node at index %d has invalid body. Creating Free Node "
+							 "instead "
 							 "of Eye Node."),
 						I));
 					const FVector WorldLocation = RouteNode.Frame.GetWorldLocation(*this);
@@ -2086,7 +2112,8 @@ void UAGX_WireComponent::CreateNative()
 				if (Body == nullptr)
 				{
 					ErrorMessages.Add(FString::Printf(
-						TEXT("Wire node at index %d has invalid body. Creating Free Node instead "
+						TEXT("Wire node at index %d has invalid body. Creating Free Node "
+							 "instead "
 							 "for Body Fixed Node."),
 						I));
 					const FVector WorldLocation = RouteNode.Frame.GetWorldLocation(*this);
@@ -2099,9 +2126,9 @@ void UAGX_WireComponent::CreateNative()
 			case EWireNodeType::Other:
 				UE_LOG(
 					LogAGX, Warning,
-					TEXT(
-						"Found unexpected node type in Wire '%s', part of actor '%s', at index %d. "
-						"Node ignored."),
+					TEXT("Found unexpected node type in Wire '%s', part of actor '%s', at "
+						 "index %d. "
+						 "Node ignored."),
 					*GetName(), *GetLabelSafe(GetOwner()), I);
 				break;
 		}
@@ -2358,9 +2385,9 @@ void UAGX_WireComponent::SynchronizeParentMovedCallbacks()
 	// remove an entry from the Delegate Handles list when the parent no longer exists.
 	//
 	// This implementation takes a nuke-all rebuild-all approach. We used to have an incremental
-	// implementation that was a bit more complicated. If this synchronization becomes a performance
-	// problem then the old incremental implementation can be found by searching the Git patch
-	// history for the string
+	// implementation that was a bit more complicated. If this synchronization becomes a
+	// performance problem then the old incremental implementation can be found by searching the
+	// Git patch history for the string
 	//
 	//   Find parents that aren't a parent to any routing node anymore, and parents that has
 	//

--- a/Source/AGXUnreal/Private/Wire/AGX_WireComponent.cpp
+++ b/Source/AGXUnreal/Private/Wire/AGX_WireComponent.cpp
@@ -1464,6 +1464,7 @@ void UAGX_WireComponent::InitPropertyDispatcher()
 	// Dispatchers for Properties owned by Wire Parameter Controller.
 	ADD_PARAMETER_CONTROLLER_DISPACTCHER(MaximumContactMovementOneTimestep);
 	ADD_PARAMETER_CONTROLLER_DISPACTCHER(MinimumDistanceBetweenNodes);
+	ADD_PARAMETER_CONTROLLER_DISPACTCHER(RadiusMultiplier);
 	ADD_PARAMETER_CONTROLLER_DISPACTCHER(ScaleConstant);
 
 	Dispatcher.Add(

--- a/Source/AGXUnreal/Private/Wire/AGX_WireComponent.cpp
+++ b/Source/AGXUnreal/Private/Wire/AGX_WireComponent.cpp
@@ -1468,6 +1468,7 @@ void UAGX_WireComponent::InitPropertyDispatcher()
 	ADD_PARAMETER_CONTROLLER_DISPACTCHER(ScaleConstant);
 	ADD_PARAMETER_CONTROLLER_DISPACTCHER(SplitTensionMultiplier);
 	ADD_PARAMETER_CONTROLLER_DISPACTCHER(StopNodeLumpMinDistanceFraction);
+	ADD_PARAMETER_CONTROLLER_DISPACTCHER(StopNodeReferenceDistance);
 
 	Dispatcher.Add(
 		GET_MEMBER_NAME_CHECKED(UAGX_WireComponent, RenderMaterial),

--- a/Source/AGXUnreal/Private/Wire/AGX_WireComponent.cpp
+++ b/Source/AGXUnreal/Private/Wire/AGX_WireComponent.cpp
@@ -1463,6 +1463,7 @@ void UAGX_WireComponent::InitPropertyDispatcher()
 
 	// Dispatchers for Properties owned by Wire Parameter Controller.
 	ADD_PARAMETER_CONTROLLER_DISPACTCHER(MaximumContactMovementOneTimestep);
+	ADD_PARAMETER_CONTROLLER_DISPACTCHER(MinimumDistanceBetweenNodes);
 	ADD_PARAMETER_CONTROLLER_DISPACTCHER(ScaleConstant);
 
 	Dispatcher.Add(

--- a/Source/AGXUnreal/Private/Wire/AGX_WireComponent.cpp
+++ b/Source/AGXUnreal/Private/Wire/AGX_WireComponent.cpp
@@ -1466,6 +1466,7 @@ void UAGX_WireComponent::InitPropertyDispatcher()
 	ADD_PARAMETER_CONTROLLER_DISPACTCHER(MinimumDistanceBetweenNodes);
 	ADD_PARAMETER_CONTROLLER_DISPACTCHER(RadiusMultiplier);
 	ADD_PARAMETER_CONTROLLER_DISPACTCHER(ScaleConstant);
+	ADD_PARAMETER_CONTROLLER_DISPACTCHER(SplitTensionMultiplier);
 
 	Dispatcher.Add(
 		GET_MEMBER_NAME_CHECKED(UAGX_WireComponent, RenderMaterial),

--- a/Source/AGXUnreal/Private/Wire/AGX_WireComponent.cpp
+++ b/Source/AGXUnreal/Private/Wire/AGX_WireComponent.cpp
@@ -1263,6 +1263,7 @@ void UAGX_WireComponent::CopyFrom(const FWireBarrier& Barrier)
 	MinSegmentLength = 1.0f / Barrier.GetResolutionPerUnitLength();
 	LinearVelocityDamping = static_cast<float>(Barrier.GetLinearVelocityDamping());
 	bCanCollide = Barrier.GetEnableCollisions();
+	WireParameterController.CopyFrom(Barrier.GetParameterController());
 
 	for (const FName& Group : Barrier.GetCollisionGroups())
 	{
@@ -1296,11 +1297,14 @@ void UAGX_WireComponent::SetNativeAddress(uint64 NativeAddress)
 {
 	check(!HasNative());
 	NativeBarrier.SetNativeAddress(static_cast<uintptr_t>(NativeAddress));
-	WireParameterController.SetBarrier(NativeBarrier.GetParameterController());
-
 	if (HasNative())
 	{
+		WireParameterController.SetBarrier(NativeBarrier.GetParameterController());
 		MergeSplitProperties.BindBarrierToOwner(*GetNative());
+	}
+	else
+	{
+		WireParameterController.ClearBarrier();
 	}
 }
 
@@ -1688,7 +1692,7 @@ void UAGX_WireComponent::EndPlay(const EEndPlayReason::Type Reason)
 	if (HasNative())
 	{
 		NativeBarrier.ReleaseNative();
-		WireParameterController.SetBarrier(FWireParameterControllerBarrier());
+		WireParameterController.ClearBarrier();
 	}
 }
 

--- a/Source/AGXUnreal/Private/Wire/AGX_WireComponent.cpp
+++ b/Source/AGXUnreal/Private/Wire/AGX_WireComponent.cpp
@@ -1469,6 +1469,7 @@ void UAGX_WireComponent::InitPropertyDispatcher()
 	ADD_PARAMETER_CONTROLLER_DISPACTCHER(SplitTensionMultiplier);
 	ADD_PARAMETER_CONTROLLER_DISPACTCHER(StopNodeLumpMinDistanceFraction);
 	ADD_PARAMETER_CONTROLLER_DISPACTCHER(StopNodeReferenceDistance);
+	ADD_PARAMETER_CONTROLLER_DISPACTCHER(WireContactDynamicsSolverDampingScale);
 
 	Dispatcher.Add(
 		GET_MEMBER_NAME_CHECKED(UAGX_WireComponent, RenderMaterial),

--- a/Source/AGXUnreal/Private/Wire/AGX_WireParameterController.cpp
+++ b/Source/AGXUnreal/Private/Wire/AGX_WireParameterController.cpp
@@ -6,10 +6,6 @@
 #include "Utilities/AGX_BarrierUtilities.h"
 #include "Wire/WireParameterControllerBarrier.h"
 
-void FAGX_WireParameterController::SetBarrier(const FWireParameterControllerBarrier& InBarrier)
-{
-	NativeBarrier = InBarrier;
-}
 
 AGX_BARRIER_SET_GET_PROPERTY(
 	FAGX_WireParameterController, double, MaximumContactMovementOneTimestep)
@@ -28,6 +24,28 @@ double FAGX_WireParameterController::GetScaledRadiusMultiplier(double WireRadius
 		return 0.0;
 	}
 	return NativeBarrier.GetScaledRadiusMultiplier(WireRadius);
+}
+
+void FAGX_WireParameterController::SetBarrier(const FWireParameterControllerBarrier& InBarrier)
+{
+	NativeBarrier = InBarrier;
+}
+
+void FAGX_WireParameterController::ClearBarrier(){
+	NativeBarrier = FWireParameterControllerBarrier();
+}
+
+
+void FAGX_WireParameterController::CopyFrom(const FWireParameterControllerBarrier& Barrier)
+{
+	MaximumContactMovementOneTimestep = Barrier.GetMaximumContactMovementOneTimestep();
+	MinimumDistanceBetweenNodes = Barrier.GetMinimumDistanceBetweenNodes();
+	RadiusMultiplier = Barrier.GetRadiusMultiplier();
+	ScaleConstant = Barrier.GetScaleConstant();
+	SplitTensionMultiplier = Barrier.GetSplitTensionMultiplier();
+	StopNodeLumpMinDistanceFraction = Barrier.GetStopNodeLumpMinDistanceFraction();
+	StopNodeReferenceDistance = Barrier.GetStopNodeReferenceDistance();
+	WireContactDynamicsSolverDampingScale = Barrier.GetWireContactDynamicsSolverDampingScale();
 }
 
 void FAGX_WireParameterController::WritePropertiesToNative()

--- a/Source/AGXUnreal/Private/Wire/AGX_WireParameterController.cpp
+++ b/Source/AGXUnreal/Private/Wire/AGX_WireParameterController.cpp
@@ -17,6 +17,16 @@ AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, MinimumDistan
 AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, RadiusMultiplier)
 AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, ScaleConstant)
 
+double FAGX_WireParameterController::GetScaledRadiusMultiplier(double WireRadius) const
+{
+	if (!HasNative())
+	{
+		return 0.0;
+	}
+	return NativeBarrier.GetScaledRadiusMultiplier(WireRadius);
+}
+
+
 void FAGX_WireParameterController::WritePropertiesToNative()
 {
 	NativeBarrier.SetMaximumContactMovementOneTimestep(MaximumContactMovementOneTimestep);

--- a/Source/AGXUnreal/Private/Wire/AGX_WireParameterController.cpp
+++ b/Source/AGXUnreal/Private/Wire/AGX_WireParameterController.cpp
@@ -17,6 +17,7 @@ AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, MinimumDistan
 AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, RadiusMultiplier)
 AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, ScaleConstant)
 AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, SplitTensionMultiplier)
+AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, StopNodeLumpMinDistanceFraction)
 
 double FAGX_WireParameterController::GetScaledRadiusMultiplier(double WireRadius) const
 {
@@ -27,7 +28,6 @@ double FAGX_WireParameterController::GetScaledRadiusMultiplier(double WireRadius
 	return NativeBarrier.GetScaledRadiusMultiplier(WireRadius);
 }
 
-
 void FAGX_WireParameterController::WritePropertiesToNative()
 {
 	NativeBarrier.SetMaximumContactMovementOneTimestep(MaximumContactMovementOneTimestep);
@@ -35,6 +35,7 @@ void FAGX_WireParameterController::WritePropertiesToNative()
 	NativeBarrier.SetRadiusMultiplier(RadiusMultiplier);
 	NativeBarrier.SetScaleConstant(ScaleConstant);
 	NativeBarrier.SetSplitTensionMultiplier(SplitTensionMultiplier);
+	NativeBarrier.SetStopNodeLumpMinDistanceFraction(StopNodeLumpMinDistanceFraction);
 }
 
 bool FAGX_WireParameterController::HasNative() const

--- a/Source/AGXUnreal/Private/Wire/AGX_WireParameterController.cpp
+++ b/Source/AGXUnreal/Private/Wire/AGX_WireParameterController.cpp
@@ -1,0 +1,42 @@
+// Copyright 2024, Algoryx Simulation AB.
+
+#include "Wire/AGX_WireParameterController.h"
+
+// AGX Dynamics for Unreal includes.
+#include "Wire/WireParameterControllerBarrier.h"
+
+void FAGX_WireParameterController::SetBarrier(const FWireParameterControllerBarrier& InBarrier)
+{
+	Barrier = InBarrier;
+}
+
+void FAGX_WireParameterController::SetScaleConstant(double InScaleConstant)
+{
+	if (HasNative())
+	{
+		Barrier.SetScaleConstant(InScaleConstant);
+	}
+	ScaleConstant = InScaleConstant;
+}
+
+double FAGX_WireParameterController::GetScaleConstant() const
+{
+	if (HasNative())
+	{
+		return Barrier.GetScaleConstant();
+	}
+	else
+	{
+		return ScaleConstant;
+	}
+}
+
+void FAGX_WireParameterController::WritePropertiesToNative()
+{
+	Barrier.SetScaleConstant(ScaleConstant);
+}
+
+bool FAGX_WireParameterController::HasNative() const
+{
+	return Barrier.HasNative();
+}

--- a/Source/AGXUnreal/Private/Wire/AGX_WireParameterController.cpp
+++ b/Source/AGXUnreal/Private/Wire/AGX_WireParameterController.cpp
@@ -13,11 +13,13 @@ void FAGX_WireParameterController::SetBarrier(const FWireParameterControllerBarr
 
 AGX_BARRIER_SET_GET_PROPERTY(
 	FAGX_WireParameterController, double, MaximumContactMovementOneTimestep)
+AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, MinimumDistanceBetweenNodes);
 AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, ScaleConstant)
 
 void FAGX_WireParameterController::WritePropertiesToNative()
 {
 	NativeBarrier.SetMaximumContactMovementOneTimestep(MaximumContactMovementOneTimestep);
+	NativeBarrier.SetMinimumDistanceBetweenNodes(MinimumDistanceBetweenNodes);
 	NativeBarrier.SetScaleConstant(ScaleConstant);
 }
 

--- a/Source/AGXUnreal/Private/Wire/AGX_WireParameterController.cpp
+++ b/Source/AGXUnreal/Private/Wire/AGX_WireParameterController.cpp
@@ -18,6 +18,7 @@ AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, RadiusMultipl
 AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, ScaleConstant)
 AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, SplitTensionMultiplier)
 AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, StopNodeLumpMinDistanceFraction)
+AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, StopNodeReferenceDistance)
 
 double FAGX_WireParameterController::GetScaledRadiusMultiplier(double WireRadius) const
 {
@@ -36,6 +37,7 @@ void FAGX_WireParameterController::WritePropertiesToNative()
 	NativeBarrier.SetScaleConstant(ScaleConstant);
 	NativeBarrier.SetSplitTensionMultiplier(SplitTensionMultiplier);
 	NativeBarrier.SetStopNodeLumpMinDistanceFraction(StopNodeLumpMinDistanceFraction);
+	NativeBarrier.SetStopNodeReferenceDistance(StopNodeReferenceDistance);
 }
 
 bool FAGX_WireParameterController::HasNative() const

--- a/Source/AGXUnreal/Private/Wire/AGX_WireParameterController.cpp
+++ b/Source/AGXUnreal/Private/Wire/AGX_WireParameterController.cpp
@@ -13,9 +13,10 @@ void FAGX_WireParameterController::SetBarrier(const FWireParameterControllerBarr
 
 AGX_BARRIER_SET_GET_PROPERTY(
 	FAGX_WireParameterController, double, MaximumContactMovementOneTimestep)
-AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, MinimumDistanceBetweenNodes);
+AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, MinimumDistanceBetweenNodes)
 AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, RadiusMultiplier)
 AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, ScaleConstant)
+AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, SplitTensionMultiplier)
 
 double FAGX_WireParameterController::GetScaledRadiusMultiplier(double WireRadius) const
 {
@@ -33,6 +34,7 @@ void FAGX_WireParameterController::WritePropertiesToNative()
 	NativeBarrier.SetMinimumDistanceBetweenNodes(MinimumDistanceBetweenNodes);
 	NativeBarrier.SetRadiusMultiplier(RadiusMultiplier);
 	NativeBarrier.SetScaleConstant(ScaleConstant);
+	NativeBarrier.SetSplitTensionMultiplier(SplitTensionMultiplier);
 }
 
 bool FAGX_WireParameterController::HasNative() const

--- a/Source/AGXUnreal/Private/Wire/AGX_WireParameterController.cpp
+++ b/Source/AGXUnreal/Private/Wire/AGX_WireParameterController.cpp
@@ -14,12 +14,14 @@ void FAGX_WireParameterController::SetBarrier(const FWireParameterControllerBarr
 AGX_BARRIER_SET_GET_PROPERTY(
 	FAGX_WireParameterController, double, MaximumContactMovementOneTimestep)
 AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, MinimumDistanceBetweenNodes);
+AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, RadiusMultiplier)
 AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, ScaleConstant)
 
 void FAGX_WireParameterController::WritePropertiesToNative()
 {
 	NativeBarrier.SetMaximumContactMovementOneTimestep(MaximumContactMovementOneTimestep);
 	NativeBarrier.SetMinimumDistanceBetweenNodes(MinimumDistanceBetweenNodes);
+	NativeBarrier.SetRadiusMultiplier(RadiusMultiplier);
 	NativeBarrier.SetScaleConstant(ScaleConstant);
 }
 

--- a/Source/AGXUnreal/Private/Wire/AGX_WireParameterController.cpp
+++ b/Source/AGXUnreal/Private/Wire/AGX_WireParameterController.cpp
@@ -19,6 +19,7 @@ AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, ScaleConstant
 AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, SplitTensionMultiplier)
 AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, StopNodeLumpMinDistanceFraction)
 AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, StopNodeReferenceDistance)
+AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, WireContactDynamicsSolverDampingScale);
 
 double FAGX_WireParameterController::GetScaledRadiusMultiplier(double WireRadius) const
 {
@@ -38,6 +39,7 @@ void FAGX_WireParameterController::WritePropertiesToNative()
 	NativeBarrier.SetSplitTensionMultiplier(SplitTensionMultiplier);
 	NativeBarrier.SetStopNodeLumpMinDistanceFraction(StopNodeLumpMinDistanceFraction);
 	NativeBarrier.SetStopNodeReferenceDistance(StopNodeReferenceDistance);
+	NativeBarrier.SetWireContactDynamicsSolverDampingScale(WireContactDynamicsSolverDampingScale);
 }
 
 bool FAGX_WireParameterController::HasNative() const

--- a/Source/AGXUnreal/Private/Wire/AGX_WireParameterController.cpp
+++ b/Source/AGXUnreal/Private/Wire/AGX_WireParameterController.cpp
@@ -3,40 +3,25 @@
 #include "Wire/AGX_WireParameterController.h"
 
 // AGX Dynamics for Unreal includes.
+#include "Utilities/AGX_BarrierUtilities.h"
 #include "Wire/WireParameterControllerBarrier.h"
 
 void FAGX_WireParameterController::SetBarrier(const FWireParameterControllerBarrier& InBarrier)
 {
-	Barrier = InBarrier;
+	NativeBarrier = InBarrier;
 }
 
-void FAGX_WireParameterController::SetScaleConstant(double InScaleConstant)
-{
-	if (HasNative())
-	{
-		Barrier.SetScaleConstant(InScaleConstant);
-	}
-	ScaleConstant = InScaleConstant;
-}
-
-double FAGX_WireParameterController::GetScaleConstant() const
-{
-	if (HasNative())
-	{
-		return Barrier.GetScaleConstant();
-	}
-	else
-	{
-		return ScaleConstant;
-	}
-}
+AGX_BARRIER_SET_GET_PROPERTY(
+	FAGX_WireParameterController, double, MaximumContactMovementOneTimestep)
+AGX_BARRIER_SET_GET_PROPERTY(FAGX_WireParameterController, double, ScaleConstant)
 
 void FAGX_WireParameterController::WritePropertiesToNative()
 {
-	Barrier.SetScaleConstant(ScaleConstant);
+	NativeBarrier.SetMaximumContactMovementOneTimestep(MaximumContactMovementOneTimestep);
+	NativeBarrier.SetScaleConstant(ScaleConstant);
 }
 
 bool FAGX_WireParameterController::HasNative() const
 {
-	return Barrier.HasNative();
+	return NativeBarrier.HasNative();
 }

--- a/Source/AGXUnreal/Public/Wire/AGX_WireComponent.h
+++ b/Source/AGXUnreal/Public/Wire/AGX_WireComponent.h
@@ -86,6 +86,12 @@ public:
 		Category = "AGX Wire")
 	FAGX_WireParameterController WireParameterController;
 
+	/**
+	 * Copy all properties from the given Parameter Controller into this Wire's Parameter Controller.
+	 *
+	 * The underlying native Parameter Controller object is not replaced, only modified. It is not
+	 * possible to use this functions to make multiple Wires share the same Parameter Controller.
+	 */
 	UFUNCTION(BlueprintSetter)
 	void SetWireParameterController(const FAGX_WireParameterController& InWireParameterController);
 

--- a/Source/AGXUnreal/Public/Wire/AGX_WireComponent.h
+++ b/Source/AGXUnreal/Public/Wire/AGX_WireComponent.h
@@ -81,7 +81,9 @@ public:
 		Meta = (ClampMin = "0", UIMin = "0"))
 	float LinearVelocityDamping = 0.0f;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, BlueprintSetter = SetWireParameterController, Category = "AGX Wire")
+	UPROPERTY(
+		EditAnywhere, BlueprintReadWrite, BlueprintSetter = SetWireParameterController,
+		Category = "AGX Wire")
 	FAGX_WireParameterController WireParameterController;
 
 	UFUNCTION(BlueprintSetter)
@@ -825,14 +827,11 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "AGX Wire")
 	double GetRestLength() const;
 
-
 	UFUNCTION(BlueprintCallable, Category = "AGX Wire")
 	double GetMass() const;
 
-
 	UFUNCTION(BlueprintCallable, Category = "AGX Wire")
 	double GetTension() const;
-
 
 	/// @return True if this wire has at least one renderable simulation node.
 	UFUNCTION(BlueprintCallable, Category = "AGX Wire")
@@ -943,7 +942,6 @@ public:
 	//~ End Scene Component interface.
 
 private: // Deprecated functions.
-
 	UFUNCTION(
 		BlueprintCallable, Category = "AGX Wire",
 		Meta =
@@ -961,7 +959,6 @@ private: // Deprecated functions.
 		Meta = (DeprecatedFunction, DeprecationMessage = "Use GetTension instead of GetTension_BP"))
 	float GetTension_BP() const;
 
-
 protected:
 	// ~Begin UActorComponent interface.
 	virtual void OnRegister() override;
@@ -969,7 +966,6 @@ protected:
 	// ~End UActorComponent interface.
 
 private:
-
 #if WITH_EDITOR
 	void InitPropertyDispatcher();
 #endif

--- a/Source/AGXUnreal/Public/Wire/AGX_WireComponent.h
+++ b/Source/AGXUnreal/Public/Wire/AGX_WireComponent.h
@@ -7,6 +7,7 @@
 #include "AMOR/AGX_WireMergeSplitProperties.h"
 #include "Wire/AGX_WireEnums.h"
 #include "Wire/AGX_WireRoutingNode.h"
+#include "Wire/AGX_WireParameterController.h"
 #include "Wire/AGX_WireWinch.h"
 #include "Wire/WireBarrier.h"
 
@@ -80,15 +81,11 @@ public:
 		Meta = (ClampMin = "0", UIMin = "0"))
 	float LinearVelocityDamping = 0.0f;
 
-	// Not sure what this is, or if we should expose it.
-	///**
-	// * Value that indicates how likely it is that mass nodes appears along the wire. Higher value
-	// * means more likely.
-	// */
-	// UPROPERTY(
-	//	EditAnywhere, BlueprintReadWrite, Category = "AGX Wire",
-	//	Meta = (ClampMin = "0", UIMin = "0"))
-	// float ScaleConstant = 0.35f;
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, BlueprintSetter = SetWireParameterController, Category = "AGX Wire")
+	FAGX_WireParameterController WireParameterController;
+
+	UFUNCTION(BlueprintSetter)
+	void SetWireParameterController(const FAGX_WireParameterController& InWireParameterController);
 
 	/**
 	 * Defines physical properties of the wire.

--- a/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
+++ b/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
@@ -40,6 +40,16 @@ struct AGXUNREAL_API FAGX_WireParameterController
 	double GetMinimumDistanceBetweenNodes() const;
 
 	/**
+	 * Set the wire sphere sphare radius multiplier.
+	 *
+	 * It's convenient to have larger geometry spheres for the lumped elements in a wire. It looks
+	 * more natural and it helps the contact handling in the wires.
+	 */
+	UPROPERTY(EditAnywhere, Category = "Wire Parameter Controller")
+	double RadiusMultiplier {1.001};
+	void SetRadiusMultiplier(double Multiplier);
+	double GetRadiusMultiplier() const;
+
 	/**
 	 * The scale constant controls the insert/remove of lumped nodes in a wire.
 	 *
@@ -110,10 +120,35 @@ class AGXUNREAL_API UAGX_WireParameterController_FL : public UBlueprintFunctionL
 	}
 
 	/**
+	 * Set the wire sphere shape radius multiplier.
+	 *
+	 * It's convenient to have larger geometry spheres for the lumped elements in a wire. It looks
+	 * more natural and it helps the contact handling in the wires.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "AGX Wire Parameter Controller")
+	static void SetRadiusMultiplier(
+		UPARAM(Ref) FAGX_WireParameterController& Controller, double RadiusMultiplier)
+	{
+		Controller.SetRadiusMultiplier(RadiusMultiplier);
+	}
+
+	/**
+	 * Get the wire sphere shape radius multiplier.
+	 *
+	 * It's convenient to have larger geometry spheres for the lumped elements in a wire. It
+	 * looks more natural and it helps the contact handling in the wires.
+	 */
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "AGX Wire Parameter Controller")
+	static double GetRadiusMultiplier(UPARAM(Ref) FAGX_WireParameterController& Controller)
+	{
+		return Controller.GetRadiusMultiplier();
+	}
+
+	/**
 	 * The scale constant controls the insert/remove of lumped nodes in a wire.
 	 *
-	 * The parameter has an analytical value derived given the Nyquist frequency. The probability to
-	 * have more lumped nodes in the wire increases with this scale constant.
+	 * The parameter has an analytical value derived given the Nyquist frequency. The
+	 * probability to have more lumped nodes in the wire increases with this scale constant.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "AGX Wire Parameter Controller")
 	static void SetScaleConstant(
@@ -125,8 +160,8 @@ class AGXUNREAL_API UAGX_WireParameterController_FL : public UBlueprintFunctionL
 	/**
 	 * The scale constant controls the insert/remove of lumped nodes in a wire.
 	 *
-	 * The parameter has an analytical value derived given the Nyquist frequency. The probability to
-	 * have more lumped nodes in the wire increases with this scale constant.
+	 * The parameter has an analytical value derived given the Nyquist frequency. The
+	 * probability to have more lumped nodes in the wire increases with this scale constant.
 	 */
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "AGX Wire Parameter Controller")
 	static double GetScaleConstant(UPARAM(Ref) FAGX_WireParameterController& Controller)

--- a/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
+++ b/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
@@ -63,6 +63,16 @@ struct AGXUNREAL_API FAGX_WireParameterController
 	void SetScaleConstant(double InScaleConstant);
 	double GetScaleConstant() const;
 
+	/**
+	 * A multiplier for tension scaling when deciding if a constraint could be replaced with a
+	 * force.
+	 */
+	UPROPERTY(EditAnywhere, Category = "Wire Parameter Controller")
+	double SplitTensionMultiplier {2.0};
+	void SetSplitTensionMultiplier(double Multiplier);
+	double GetSplitTensionMultiplier() const;
+
+
 	void WritePropertiesToNative();
 	bool HasNative() const;
 
@@ -153,7 +163,8 @@ class AGXUNREAL_API UAGX_WireParameterController_FL : public UBlueprintFunctionL
 	 * @return Scaled wire radius parameter.
 	 */
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "AGX Wire Parameter Controller")
-	static double GetScaledRadiusMultiplier(UPARAM(Ref) FAGX_WireParameterController& Controller, double WireRadius)
+	static double GetScaledRadiusMultiplier(
+		UPARAM(Ref) FAGX_WireParameterController& Controller, double WireRadius)
 	{
 		return Controller.GetScaledRadiusMultiplier(WireRadius);
 	}
@@ -181,5 +192,23 @@ class AGXUNREAL_API UAGX_WireParameterController_FL : public UBlueprintFunctionL
 	static double GetScaleConstant(UPARAM(Ref) FAGX_WireParameterController& Controller)
 	{
 		return Controller.GetScaleConstant();
+	}
+
+	/**
+	 * A multiplier for tension scaling when deciding if a constraint could be replaced with a force.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "AGX Wire Parameter Controller")
+	static void SetSplitTensionMultiplier(UPARAM(Ref) FAGX_WireParameterController& Controller, double Multiplier)
+	{
+		Controller.SetSplitTensionMultiplier(Multiplier);
+	}
+
+	/**
+	 * A multiplier for tension scaling when deciding if a constraint could be replaced with a force.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "AGX Wire Parameter Controller")
+	static double GetSplitTensionMultiplier(UPARAM(Ref) FAGX_WireParameterController& Controller)
+	{
+		return Controller.GetSplitTensionMultiplier();
 	}
 };

--- a/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
+++ b/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
@@ -94,6 +94,17 @@ struct AGXUNREAL_API FAGX_WireParameterController
 	void SetStopNodeReferenceDistance(double Distance);
 	double GetStopNodeReferenceDistance() const;
 
+	/**
+	 * A scale for the damping of the dynamics solver for ShapeContactNodes.
+	 *
+	 * This will scale the damping of the damping found in the material parameters for an
+	 * interaction of a wire/other contact.
+	 */
+	UPROPERTY(EditAnywhere, Category = "Wire Parameter Controller")
+	double WireContactDynamicsSolverDampingScale {2};
+	void SetWireContactDynamicsSolverDampingScale(double Scale);
+	double GetWireContactDynamicsSolverDampingScale() const;
+
 	void WritePropertiesToNative();
 	bool HasNative() const;
 
@@ -269,7 +280,8 @@ class AGXUNREAL_API UAGX_WireParameterController_FL : public UBlueprintFunctionL
 	 * but the behavior can be strange. Default: 1 m, equivalent to winch speed of 60 m/s in 60 Hz.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "AGX Wire Parameter Controller")
-	static void SetStopNodeReferenceDistance(UPARAM(Ref) FAGX_WireParameterController& Controller, double Distance)
+	static void SetStopNodeReferenceDistance(
+		UPARAM(Ref) FAGX_WireParameterController& Controller, double Distance)
 	{
 		Controller.SetStopNodeReferenceDistance(Distance);
 	}
@@ -280,9 +292,31 @@ class AGXUNREAL_API UAGX_WireParameterController_FL : public UBlueprintFunctionL
 	 * This also defines the theoretic maximum speed, in fact, in practice the speed can be higher
 	 * but the behavior can be strange. Default: 1 m, equivalent to winch speed of 60 m/s in 60 Hz.
 	 */
-	UFUNCTION(BlueprintCallable, BlueprintPure, Category  = "AGX Wire Parameter Controller")
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "AGX Wire Parameter Controller")
 	static double GetStopNodeReferenceDistance(UPARAM(Ref) FAGX_WireParameterController& Controller)
 	{
 		return Controller.GetStopNodeReferenceDistance();
+	}
+
+	/**
+	 * A scale for the damping of the dynamics solver for ShapeContactNodes.
+	 *
+	 * This will scale the damping of the damping found in the material parameters for an interaction of a wire/other contact.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "AGX Wire Parameter Controller")
+	static void SetWireContactDynamicsSolverDampingScale(UPARAM(Ref) FAGX_WireParameterController& Controller, double Scale)
+	{
+		Controller.SetWireContactDynamicsSolverDampingScale(Scale);
+	}
+
+	/**
+	 * A scale for the damping of the dynamics solver for ShapeContactNodes.
+	 *
+	 * This will scale the damping of the damping found in the material parameters for an interaction of a wire/other contact.
+	 */
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "AGX Wire Parameter Controller")
+	static double GetWireContactDynamicsSolverDampingScale(UPARAM(Ref) FAGX_WireParameterController& Controller)
+	{
+		return  Controller.GetWireContactDynamicsSolverDampingScale();
 	}
 };

--- a/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
+++ b/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
@@ -18,8 +18,6 @@ struct AGXUNREAL_API FAGX_WireParameterController
 {
 	GENERATED_BODY()
 
-	void SetBarrier(const FWireParameterControllerBarrier& InBarrier);
-
 	/**
 	 * This value should be related the size of objects the wire is interacting with, to avoid
 	 * tunneling [cm].
@@ -105,6 +103,9 @@ struct AGXUNREAL_API FAGX_WireParameterController
 	void SetWireContactDynamicsSolverDampingScale(double Scale);
 	double GetWireContactDynamicsSolverDampingScale() const;
 
+	void SetBarrier(const FWireParameterControllerBarrier& InBarrier);
+	void ClearBarrier();
+	void CopyFrom(const FWireParameterControllerBarrier& Barrier);
 	void WritePropertiesToNative();
 	bool HasNative() const;
 

--- a/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
+++ b/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
@@ -40,7 +40,7 @@ struct AGXUNREAL_API FAGX_WireParameterController
 	double GetMinimumDistanceBetweenNodes() const;
 
 	/**
-	 * Set the wire sphere sphare radius multiplier.
+	 * Set the wire sphere shape radius multiplier.
 	 *
 	 * It's convenient to have larger geometry spheres for the lumped elements in a wire. It looks
 	 * more natural and it helps the contact handling in the wires.
@@ -72,6 +72,16 @@ struct AGXUNREAL_API FAGX_WireParameterController
 	void SetSplitTensionMultiplier(double Multiplier);
 	double GetSplitTensionMultiplier() const;
 
+	/**
+	 * The fraction of stop node reference distance that defines the range end of the prismatic
+	 * constraint used by most winches.
+	 *
+	 * Default: 0.05 which means 5 cm if stop node reference distance is 100 cm.
+	 */
+	UPROPERTY(EditAnywhere, Category = "Wire Parameter Controller")
+	double StopNodeLumpMinDistanceFraction {0.05};
+	void SetStopNodeLumpMinDistanceFraction(double Fraction);
+	double GetStopNodeLumpMinDistanceFraction() const;
 
 	void WritePropertiesToNative();
 	bool HasNative() const;
@@ -195,20 +205,49 @@ class AGXUNREAL_API UAGX_WireParameterController_FL : public UBlueprintFunctionL
 	}
 
 	/**
-	 * A multiplier for tension scaling when deciding if a constraint could be replaced with a force.
+	 * A multiplier for tension scaling when deciding if a constraint could be replaced with a
+	 * force.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "AGX Wire Parameter Controller")
-	static void SetSplitTensionMultiplier(UPARAM(Ref) FAGX_WireParameterController& Controller, double Multiplier)
+	static void SetSplitTensionMultiplier(
+		UPARAM(Ref) FAGX_WireParameterController& Controller, double Multiplier)
 	{
 		Controller.SetSplitTensionMultiplier(Multiplier);
 	}
 
 	/**
-	 * A multiplier for tension scaling when deciding if a constraint could be replaced with a force.
+	 * A multiplier for tension scaling when deciding if a constraint could be replaced with a
+	 * force.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "AGX Wire Parameter Controller")
 	static double GetSplitTensionMultiplier(UPARAM(Ref) FAGX_WireParameterController& Controller)
 	{
 		return Controller.GetSplitTensionMultiplier();
+	}
+
+	/**
+	 * The fraction of stop node reference distance that defines the range end of the prismatic
+	 * constraint used by most winches.
+	 *
+	 * Default: 0.05 which means 5 cm if stop node reference distance is 100 cm.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "AGX Wire Parameter Controller")
+	static void SetStopNodeLumpMinDistanceFraction(
+		UPARAM(Ref) FAGX_WireParameterController& Controller, double Fraction)
+	{
+		Controller.SetStopNodeLumpMinDistanceFraction(Fraction);
+	}
+
+	/**
+	 * The fraction of stop node reference distance that defines the range end of the prismatic
+	 * constraint used by most winches.
+	 *
+	 * Default: 0.05 which means 5 cm if stop node reference distance is 100 cm.
+	 */
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "AGX Wire Parameter Controller")
+	static double GetStopNodeLumpMinDistanceFraction(UPARAM(Ref)
+														 FAGX_WireParameterController& Controller)
+	{
+		return Controller.GetStopNodeLumpMinDistanceFraction();
 	}
 };

--- a/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
+++ b/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
@@ -83,6 +83,17 @@ struct AGXUNREAL_API FAGX_WireParameterController
 	void SetStopNodeLumpMinDistanceFraction(double Fraction);
 	double GetStopNodeLumpMinDistanceFraction() const;
 
+	/**
+	 * The distance between the lump node and the stop node for winches [cm].
+	 *
+	 * This also defines the theoretic maximum speed, in fact, in practice the speed can be higher
+	 * but the behavior can be strange. Default: 1 m, equivalent to winch speed of 60 m/s in 60 Hz.
+	 */
+	UPROPERTY(EditAnywhere, Category = "Wire Parameter Controller")
+	double StopNodeReferenceDistance {100};
+	void SetStopNodeReferenceDistance(double Distance);
+	double GetStopNodeReferenceDistance() const;
+
 	void WritePropertiesToNative();
 	bool HasNative() const;
 
@@ -249,5 +260,29 @@ class AGXUNREAL_API UAGX_WireParameterController_FL : public UBlueprintFunctionL
 														 FAGX_WireParameterController& Controller)
 	{
 		return Controller.GetStopNodeLumpMinDistanceFraction();
+	}
+
+	/**
+	 * The distance between the lump node and the stop node for winches [cm].
+	 *
+	 * This also defines the theoretic maximum speed, in fact, in practice the speed can be higher
+	 * but the behavior can be strange. Default: 1 m, equivalent to winch speed of 60 m/s in 60 Hz.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "AGX Wire Parameter Controller")
+	static void SetStopNodeReferenceDistance(UPARAM(Ref) FAGX_WireParameterController& Controller, double Distance)
+	{
+		Controller.SetStopNodeReferenceDistance(Distance);
+	}
+
+	/**
+	 * The distance between the lump node and the stop node for winches [cm].
+	 *
+	 * This also defines the theoretic maximum speed, in fact, in practice the speed can be higher
+	 * but the behavior can be strange. Default: 1 m, equivalent to winch speed of 60 m/s in 60 Hz.
+	 */
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category  = "AGX Wire Parameter Controller")
+	static double GetStopNodeReferenceDistance(UPARAM(Ref) FAGX_WireParameterController& Controller)
+	{
+		return Controller.GetStopNodeReferenceDistance();
 	}
 };

--- a/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
+++ b/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
@@ -49,6 +49,8 @@ struct AGXUNREAL_API FAGX_WireParameterController
 	double RadiusMultiplier {1.001};
 	void SetRadiusMultiplier(double Multiplier);
 	double GetRadiusMultiplier() const;
+	/** Only available when there is an underlying native AGX Dynamics object. */
+	double GetScaledRadiusMultiplier(double WireRadius) const;
 
 	/**
 	 * The scale constant controls the insert/remove of lumped nodes in a wire.
@@ -142,6 +144,18 @@ class AGXUNREAL_API UAGX_WireParameterController_FL : public UBlueprintFunctionL
 	static double GetRadiusMultiplier(UPARAM(Ref) FAGX_WireParameterController& Controller)
 	{
 		return Controller.GetRadiusMultiplier();
+	}
+
+	/**
+	 *
+	 * @param Controller Wire Parameter Controller to read from.
+	 * @param WireRadius The radius of the wire [cm].
+	 * @return Scaled wire radius parameter.
+	 */
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "AGX Wire Parameter Controller")
+	static double GetScaledRadiusMultiplier(UPARAM(Ref) FAGX_WireParameterController& Controller, double WireRadius)
+	{
+		return Controller.GetScaledRadiusMultiplier(WireRadius);
 	}
 
 	/**

--- a/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
+++ b/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
@@ -22,16 +22,17 @@ struct AGXUNREAL_API FAGX_WireParameterController
 
 	/**
 	 * This value should be related the size of objects the wire is interacting with, to avoid
-	 * tunneling.
+	 * tunneling [cm].
 	 */
 	UPROPERTY(EditAnywhere, Category = "Wire Parameter Controller")
-	double MaximumContactMovementOneTimestep {0.1};
+	double MaximumContactMovementOneTimestep {10.0};
 	void SetMaximumContactMovementOneTimestep(double MaxMovement);
 	double GetMaximumContactMovementOneTimestep() const;
 
 	/**
-	 * Set the minimum distance allowed between nodes. I.e., a lumped element node will NOT
-	 * be created closer than this distance from routed nodes.
+	 * Set the minimum distance allowed between nodes [cm].
+	 *
+	 * I.e., a lumped element node will NOT be created closer than this distance from routed nodes.
 	 */
 	UPROPERTY(EditAnywhere, Category = "Wire Parameter Controller")
 	double MinimumDistanceBetweenNodes {5.0};
@@ -39,9 +40,11 @@ struct AGXUNREAL_API FAGX_WireParameterController
 	double GetMinimumDistanceBetweenNodes() const;
 
 	/**
-	 * The scale constant controls the insert/remove of lumped nodes in a wire. The parameter
-	 * has an analytical value derived given the Nyquist frequency. The probability to have more
-	 * lumped nodes in the wire increases with this scale constant.
+	/**
+	 * The scale constant controls the insert/remove of lumped nodes in a wire.
+	 *
+	 * The parameter has an analytical value derived given the Nyquist frequency. The probability to
+	 * have more lumped nodes in the wire increases with this scale constant.
 	 */
 	UPROPERTY(EditAnywhere, Category = "Wire Parameter Controller")
 	double ScaleConstant {0.35};
@@ -62,7 +65,7 @@ class AGXUNREAL_API UAGX_WireParameterController_FL : public UBlueprintFunctionL
 
 	/**
 	 * This value should be related the size of objects the wire is interacting with, to avoid
-	 * tunneling.
+	 * tunneling [cm].
 	 */
 	UFUNCTION(BlueprintCallable, Category = "AGX Wire Parameter Controller")
 	static void SetMaximumContactMovementOneTimestep(
@@ -73,7 +76,7 @@ class AGXUNREAL_API UAGX_WireParameterController_FL : public UBlueprintFunctionL
 
 	/**
 	 * This value should be related the size of objects the wire is interacting with, to avoid
-	 * tunneling.
+	 * tunneling [cm].
 	 */
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "AGX Wire Parameter Controller")
 	static double GetMaximumContactMovementOneTimeStep(UPARAM(Ref)
@@ -83,29 +86,34 @@ class AGXUNREAL_API UAGX_WireParameterController_FL : public UBlueprintFunctionL
 	}
 
 	/**
-	 * Set the minimum distance allowed between nodes. I.e., a lumped element node will NOT
-	 * be created closer than this distance from routed nodes.
+	 * Set the minimum distance allowed between nodes [cm].
+	 *
+	 * I.e., a lumped element node will NOT be created closer than this distance from routed nodes.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "AGX Wire Parameter Controller")
-	static void SetMinimumDistanceBetweenNodes(UPARAM(Ref) FAGX_WireParameterController& Controller, double MinDistance)
+	static void SetMinimumDistanceBetweenNodes(
+		UPARAM(Ref) FAGX_WireParameterController& Controller, double MinDistance)
 	{
 		Controller.SetMinimumDistanceBetweenNodes(MinDistance);
 	}
 
 	/**
-	 * Set the minimum distance allowed between nodes. I.e., a lumped element node will NOT
-	 * be created closer than this distance from routed nodes.
+	 * Set the minimum distance allowed between nodes [cm].
+	 *
+	 * I.e., a lumped element node will NOT be created closer than this distance from routed nodes.
 	 */
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "AGX Wire Parameter Controller")
-	static double GetMinimumDistanceBetweenNodes(UPARAM(Ref) FAGX_WireParameterController& Controller)
+	static double GetMinimumDistanceBetweenNodes(UPARAM(Ref)
+													 FAGX_WireParameterController& Controller)
 	{
 		return Controller.GetMinimumDistanceBetweenNodes();
 	}
 
 	/**
-	 * The scale constant controls the insert/remove of lumped nodes in a wire. The parameter
-	 * has an analytical value derived given the Nyquist frequency. The probability to have more
-	 * lumped nodes in the wire increases with this scale constant.
+	 * The scale constant controls the insert/remove of lumped nodes in a wire.
+	 *
+	 * The parameter has an analytical value derived given the Nyquist frequency. The probability to
+	 * have more lumped nodes in the wire increases with this scale constant.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "AGX Wire Parameter Controller")
 	static void SetScaleConstant(
@@ -115,9 +123,10 @@ class AGXUNREAL_API UAGX_WireParameterController_FL : public UBlueprintFunctionL
 	}
 
 	/**
-	 * The scale constant controls the insert/remove of lumped nodes in a wire. The parameter
-	 * has an analytical value derived given the Nyquist frequency. The probability to have more
-	 * lumped nodes in the wire increases with this scale constant.
+	 * The scale constant controls the insert/remove of lumped nodes in a wire.
+	 *
+	 * The parameter has an analytical value derived given the Nyquist frequency. The probability to
+	 * have more lumped nodes in the wire increases with this scale constant.
 	 */
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "AGX Wire Parameter Controller")
 	static double GetScaleConstant(UPARAM(Ref) FAGX_WireParameterController& Controller)

--- a/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
+++ b/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
@@ -20,18 +20,30 @@ struct AGXUNREAL_API FAGX_WireParameterController
 
 	void SetBarrier(const FWireParameterControllerBarrier& InBarrier);
 
+	/**
+	 * This value should be related the size of objects the wire is interacting with, to avoid
+	 * tunneling.
+	 */
+	UPROPERTY(EditAnywhere, Category = "Wire Parameter Controller")
+	double MaximumContactMovementOneTimestep {0.1};
+	void SetMaximumContactMovementOneTimestep(double MaxMovement);
+	double GetMaximumContactMovementOneTimestep() const;
+
+	/**
+	 * The scale constant controls the insert/remove of lumped nodes in a wire. The parameter
+	 * has an analytical value derived given the Nyquist frequency. The probability to have more
+	 * lumped nodes in the wire increases with this scale constant.
+	 */
 	UPROPERTY(EditAnywhere, Category = "Wire Parameter Controller")
 	double ScaleConstant {0.35};
-
 	void SetScaleConstant(double InScaleConstant);
 	double GetScaleConstant() const;
 
 	void WritePropertiesToNative();
-
 	bool HasNative() const;
 
 private:
-	FWireParameterControllerBarrier Barrier;
+	FWireParameterControllerBarrier NativeBarrier;
 };
 
 UCLASS()
@@ -39,6 +51,33 @@ class AGXUNREAL_API UAGX_WireParameterController_FL : public UBlueprintFunctionL
 {
 	GENERATED_BODY()
 
+	/**
+	 * This value should be related the size of objects the wire is interacting with, to avoid
+	 * tunneling.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "AGX Wire Parameter Controller")
+	static void SetMaximumContactMovementOneTimestep(
+		UPARAM(Ref) FAGX_WireParameterController& Controller, double MaxMovement)
+	{
+		Controller.SetMaximumContactMovementOneTimestep(MaxMovement);
+	}
+
+	/**
+	 * This value should be related the size of objects the wire is interacting with, to avoid
+	 * tunneling.
+	 */
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "AGX Wire Parameter Controller")
+	static double GetMaximumContactMovementOneTimeStep(UPARAM(Ref)
+														   FAGX_WireParameterController& Controller)
+	{
+		return Controller.GetMaximumContactMovementOneTimestep();
+	}
+
+	/**
+	 * The scale constant controls the insert/remove of lumped nodes in a wire. The parameter
+	 * has an analytical value derived given the Nyquist frequency. The probability to have more
+	 * lumped nodes in the wire increases with this scale constant.
+	 */
 	UFUNCTION(BlueprintCallable, Category = "AGX Wire Parameter Controller")
 	static void SetScaleConstant(
 		UPARAM(Ref) FAGX_WireParameterController& Controller, double ScaleConstant)
@@ -46,6 +85,11 @@ class AGXUNREAL_API UAGX_WireParameterController_FL : public UBlueprintFunctionL
 		Controller.SetScaleConstant(ScaleConstant);
 	}
 
+	/**
+	 * The scale constant controls the insert/remove of lumped nodes in a wire. The parameter
+	 * has an analytical value derived given the Nyquist frequency. The probability to have more
+	 * lumped nodes in the wire increases with this scale constant.
+	 */
 	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "AGX Wire Parameter Controller")
 	static double GetScaleConstant(UPARAM(Ref) FAGX_WireParameterController& Controller)
 	{

--- a/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
+++ b/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
@@ -1,0 +1,54 @@
+// Copyright 2024, Algoryx Simulation AB.
+
+#pragma once
+
+// AGX Dynamics for Unreal includes.
+#include "Wire/WireParameterControllerBarrier.h"
+
+// Unreal Engine includes.
+#include "CoreMinimal.h"
+#include "Kismet/BlueprintFunctionLibrary.h"
+
+#include "AGX_WireParameterController.generated.h"
+
+class FWireParameterControllerBarrier;
+
+USTRUCT(BlueprintType)
+struct AGXUNREAL_API FAGX_WireParameterController
+{
+	GENERATED_BODY()
+
+	void SetBarrier(const FWireParameterControllerBarrier& InBarrier);
+
+	UPROPERTY(EditAnywhere, Category = "Wire Parameter Controller")
+	double ScaleConstant {0.35};
+
+	void SetScaleConstant(double InScaleConstant);
+	double GetScaleConstant() const;
+
+	void WritePropertiesToNative();
+
+	bool HasNative() const;
+
+private:
+	FWireParameterControllerBarrier Barrier;
+};
+
+UCLASS()
+class AGXUNREAL_API UAGX_WireParameterController_FL : public UBlueprintFunctionLibrary
+{
+	GENERATED_BODY()
+
+	UFUNCTION(BlueprintCallable, Category = "AGX Wire Parameter Controller")
+	static void SetScaleConstant(
+		UPARAM(Ref) FAGX_WireParameterController& Controller, double ScaleConstant)
+	{
+		Controller.SetScaleConstant(ScaleConstant);
+	}
+
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "AGX Wire Parameter Controller")
+	static double GetScaleConstant(UPARAM(Ref) FAGX_WireParameterController& Controller)
+	{
+		return Controller.GetScaleConstant();
+	}
+};

--- a/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
+++ b/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
@@ -241,7 +241,7 @@ class AGXUNREAL_API UAGX_WireParameterController_FL : public UBlueprintFunctionL
 	 * A multiplier for tension scaling when deciding if a constraint could be replaced with a
 	 * force.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "AGX Wire Parameter Controller")
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "AGX Wire Parameter Controller")
 	static double GetSplitTensionMultiplier(UPARAM(Ref) FAGX_WireParameterController& Controller)
 	{
 		return Controller.GetSplitTensionMultiplier();

--- a/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
+++ b/Source/AGXUnreal/Public/Wire/AGX_WireParameterController.h
@@ -30,6 +30,15 @@ struct AGXUNREAL_API FAGX_WireParameterController
 	double GetMaximumContactMovementOneTimestep() const;
 
 	/**
+	 * Set the minimum distance allowed between nodes. I.e., a lumped element node will NOT
+	 * be created closer than this distance from routed nodes.
+	 */
+	UPROPERTY(EditAnywhere, Category = "Wire Parameter Controller")
+	double MinimumDistanceBetweenNodes {5.0};
+	void SetMinimumDistanceBetweenNodes(double MinDistance);
+	double GetMinimumDistanceBetweenNodes() const;
+
+	/**
 	 * The scale constant controls the insert/remove of lumped nodes in a wire. The parameter
 	 * has an analytical value derived given the Nyquist frequency. The probability to have more
 	 * lumped nodes in the wire increases with this scale constant.
@@ -71,6 +80,26 @@ class AGXUNREAL_API UAGX_WireParameterController_FL : public UBlueprintFunctionL
 														   FAGX_WireParameterController& Controller)
 	{
 		return Controller.GetMaximumContactMovementOneTimestep();
+	}
+
+	/**
+	 * Set the minimum distance allowed between nodes. I.e., a lumped element node will NOT
+	 * be created closer than this distance from routed nodes.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "AGX Wire Parameter Controller")
+	static void SetMinimumDistanceBetweenNodes(UPARAM(Ref) FAGX_WireParameterController& Controller, double MinDistance)
+	{
+		Controller.SetMinimumDistanceBetweenNodes(MinDistance);
+	}
+
+	/**
+	 * Set the minimum distance allowed between nodes. I.e., a lumped element node will NOT
+	 * be created closer than this distance from routed nodes.
+	 */
+	UFUNCTION(BlueprintCallable, BlueprintPure, Category = "AGX Wire Parameter Controller")
+	static double GetMinimumDistanceBetweenNodes(UPARAM(Ref) FAGX_WireParameterController& Controller)
+	{
+		return Controller.GetMinimumDistanceBetweenNodes();
 	}
 
 	/**

--- a/Source/AGXUnrealBarrier/Private/Wire/WireBarrier.cpp
+++ b/Source/AGXUnrealBarrier/Private/Wire/WireBarrier.cpp
@@ -5,13 +5,15 @@
 // AGX Unreal includes.
 #include "AGXBarrierFactories.h"
 #include "BarrierOnly/AGXRefs.h"
+#include "BarrierOnly/Wire/WireNodeRef.h"
+#include "BarrierOnly/Wire/WireParameterControllerPtr.h"
+#include "BarrierOnly/Wire/WireRef.h"
+#include "BarrierOnly/Wire/WireWinchRef.h"
 #include "Materials/ShapeMaterialBarrier.h"
 #include "TypeConversions.h"
 #include "Wire/WireNodeBarrier.h"
-#include "BarrierOnly/Wire/WireNodeRef.h"
-#include "BarrierOnly/Wire/WireRef.h"
 #include "Wire/WireWinchBarrier.h"
-#include "BarrierOnly/Wire/WireWinchRef.h"
+#include "Wire/WireParameterControllerBarrier.h"
 
 // AGX Dynamics includes.
 #include "BeginAGXIncludes.h"
@@ -263,6 +265,12 @@ double FWireBarrier::GetTension() const
 
 	/// \todo Do tension need conversion to Unreal units?
 	return Data.raw;
+}
+
+FWireParameterControllerBarrier FWireBarrier::GetParameterController() const
+{
+	return FWireParameterControllerBarrier(
+		std::make_unique<FWireParameterControllerPtr>(NativeRef->Native));
 }
 
 bool FWireBarrier::Attach(FWireWinchBarrier& Winch, bool bBegin)

--- a/Source/AGXUnrealBarrier/Private/Wire/WireParameterControllerBarrier.cpp
+++ b/Source/AGXUnrealBarrier/Private/Wire/WireParameterControllerBarrier.cpp
@@ -140,9 +140,24 @@ void FWireParameterControllerBarrier::SetStopNodeReferenceDistance(double Distan
 double FWireParameterControllerBarrier::GetStopNodeReferenceDistance() const
 {
 	check(HasNative());
-	const agx::Real DistanceAGX = NativePtr->NativeWire->getParameterController()->getStopNodeReferenceDistance();
+	const agx::Real DistanceAGX =
+		NativePtr->NativeWire->getParameterController()->getStopNodeReferenceDistance();
 	const double Distance = ConvertToUnreal<double>(DistanceAGX);
 	return Distance;
+}
+
+void FWireParameterControllerBarrier::SetWireContactDynamicsSolverDampingScale(double Scale)
+{
+	check(HasNative());
+	NativePtr->NativeWire->getParameterController()->setWireContactDynamicsSolverDampingScale(
+		Scale);
+}
+
+double FWireParameterControllerBarrier::GetWireContactDynamicsSolverDampingScale() const
+{
+	check(HasNative());
+	return NativePtr->NativeWire->getParameterController()
+		->getWireContactDynamicsSolverDampingScale();
 }
 
 bool FWireParameterControllerBarrier::HasNative() const

--- a/Source/AGXUnrealBarrier/Private/Wire/WireParameterControllerBarrier.cpp
+++ b/Source/AGXUnrealBarrier/Private/Wire/WireParameterControllerBarrier.cpp
@@ -87,6 +87,13 @@ double FWireParameterControllerBarrier::GetRadiusMultiplier() const
 	return NativePtr->NativeWire->getParameterController()->getNonScaledRadiusMultiplier();
 }
 
+double FWireParameterControllerBarrier::GetScaledRadiusMultiplier(double WireRadius) const
+{
+	check(HasNative());
+	const double WireRadiusAGX = ConvertDistanceToAGX(WireRadius);
+	return NativePtr->NativeWire->getParameterController()->getRadiusMultiplier(WireRadius);
+}
+
 void FWireParameterControllerBarrier::SetScaleConstant(double ScaleConstant)
 {
 	check(HasNative());

--- a/Source/AGXUnrealBarrier/Private/Wire/WireParameterControllerBarrier.cpp
+++ b/Source/AGXUnrealBarrier/Private/Wire/WireParameterControllerBarrier.cpp
@@ -130,6 +130,21 @@ double FWireParameterControllerBarrier::GetStopNodeLumpMinDistanceFraction() con
 	return NativePtr->NativeWire->getParameterController()->getStopNodeLumpMinDistanceFraction();
 }
 
+void FWireParameterControllerBarrier::SetStopNodeReferenceDistance(double Distance)
+{
+	check(HasNative());
+	const agx::Real DistanceAGX = ConvertDistanceToAGX(Distance);
+	NativePtr->NativeWire->getParameterController()->setStopNodeReferenceDistance(DistanceAGX);
+}
+
+double FWireParameterControllerBarrier::GetStopNodeReferenceDistance() const
+{
+	check(HasNative());
+	const agx::Real DistanceAGX = NativePtr->NativeWire->getParameterController()->getStopNodeReferenceDistance();
+	const double Distance = ConvertToUnreal<double>(DistanceAGX);
+	return Distance;
+}
+
 bool FWireParameterControllerBarrier::HasNative() const
 {
 	return NativePtr->NativeWire != nullptr;

--- a/Source/AGXUnrealBarrier/Private/Wire/WireParameterControllerBarrier.cpp
+++ b/Source/AGXUnrealBarrier/Private/Wire/WireParameterControllerBarrier.cpp
@@ -106,6 +106,18 @@ double FWireParameterControllerBarrier::GetScaleConstant() const
 	return NativePtr->NativeWire->getParameterController()->getScaleConstant();
 }
 
+void FWireParameterControllerBarrier::SetSplitTensionMultiplier(double Multiplier)
+{
+	check(HasNative());
+	NativePtr->NativeWire->getParameterController()->setSplitTensionMultiplier(Multiplier);
+}
+
+double FWireParameterControllerBarrier::GetSplitTensionMultiplier() const
+{
+	check(HasNative());
+	return NativePtr->NativeWire->getParameterController()->getSplitTensionMultiplier();
+}
+
 bool FWireParameterControllerBarrier::HasNative() const
 {
 	return NativePtr->NativeWire != nullptr;

--- a/Source/AGXUnrealBarrier/Private/Wire/WireParameterControllerBarrier.cpp
+++ b/Source/AGXUnrealBarrier/Private/Wire/WireParameterControllerBarrier.cpp
@@ -1,0 +1,60 @@
+// Copyright 2024, Algoryx Simulation AB.
+
+#include "Wire/WireParameterControllerBarrier.h"
+
+// AGX Dynamics for Unreal includes.
+#include "AGX_LogCategory.h"
+#include "BarrierOnly/Wire/WireParameterControllerPtr.h"
+
+FWireParameterControllerBarrier::FWireParameterControllerBarrier()
+	: NativePtr {new FWireParameterControllerPtr()}
+{
+}
+
+FWireParameterControllerBarrier::FWireParameterControllerBarrier(
+	std::unique_ptr<FWireParameterControllerPtr> Native)
+	: NativePtr {std::move(Native)}
+{
+}
+
+FWireParameterControllerBarrier::FWireParameterControllerBarrier(
+	const FWireParameterControllerBarrier& Other)
+	: NativePtr {new FWireParameterControllerPtr(Other.NativePtr->NativeWire)}
+{
+}
+
+FWireParameterControllerBarrier::FWireParameterControllerBarrier(
+	FWireParameterControllerBarrier&& Other)
+	: NativePtr {std::move(Other.NativePtr)}
+{
+}
+
+FWireParameterControllerBarrier::~FWireParameterControllerBarrier()
+{
+	// Destructor definition must be in the .cpp file since the definition, not just the
+	// declaration, of FWireParameterControllerPtr must be available.
+}
+
+FWireParameterControllerBarrier& FWireParameterControllerBarrier::operator=(
+	const FWireParameterControllerBarrier& Other)
+{
+	*NativePtr = *Other.NativePtr;
+	return *this;
+}
+
+void FWireParameterControllerBarrier::SetScaleConstant(double ScaleConstant)
+{
+	check(HasNative());
+	NativePtr->NativeWire->getParameterController()->setScaleConstant(ScaleConstant);
+}
+
+double FWireParameterControllerBarrier::GetScaleConstant() const
+{
+	check(HasNative());
+	return NativePtr->NativeWire->getParameterController()->getScaleConstant();
+}
+
+bool FWireParameterControllerBarrier::HasNative() const
+{
+	return NativePtr->NativeWire != nullptr;
+}

--- a/Source/AGXUnrealBarrier/Private/Wire/WireParameterControllerBarrier.cpp
+++ b/Source/AGXUnrealBarrier/Private/Wire/WireParameterControllerBarrier.cpp
@@ -75,6 +75,18 @@ double FWireParameterControllerBarrier::GetMinimumDistanceBetweenNodes() const
 	return MinDistance;
 }
 
+void FWireParameterControllerBarrier::SetRadiusMultiplier(double RadiusMultiplier)
+{
+	check(HasNative());
+	NativePtr->NativeWire->getParameterController()->setRadiusMultiplier(RadiusMultiplier);
+}
+
+double FWireParameterControllerBarrier::GetRadiusMultiplier() const
+{
+	check(HasNative());
+	return NativePtr->NativeWire->getParameterController()->getNonScaledRadiusMultiplier();
+}
+
 void FWireParameterControllerBarrier::SetScaleConstant(double ScaleConstant)
 {
 	check(HasNative());

--- a/Source/AGXUnrealBarrier/Private/Wire/WireParameterControllerBarrier.cpp
+++ b/Source/AGXUnrealBarrier/Private/Wire/WireParameterControllerBarrier.cpp
@@ -45,18 +45,34 @@ FWireParameterControllerBarrier& FWireParameterControllerBarrier::operator=(
 void FWireParameterControllerBarrier::SetMaximumContactMovementOneTimestep(double MaxMovement)
 {
 	check(HasNative());
-	const double MaxMovementAgx = ConvertDistanceToAGX(MaxMovement);
+	const double MaxMovementAGX = ConvertDistanceToAGX(MaxMovement);
 	NativePtr->NativeWire->getParameterController()->setMaximumContactMovementOneTimestep(
-		MaxMovementAgx);
+		MaxMovementAGX);
 }
 
 double FWireParameterControllerBarrier::GetMaximumContactMovementOneTimestep() const
 {
 	check(HasNative());
-	const double MaxMovementAgx =
+	const double MaxMovementAGX =
 		NativePtr->NativeWire->getParameterController()->getMaximumContactMovementOneTimestep();
-	const double MaxMovement = ConvertDistanceToUnreal<double>(MaxMovementAgx);
+	const double MaxMovement = ConvertDistanceToUnreal<double>(MaxMovementAGX);
 	return MaxMovement;
+}
+
+void FWireParameterControllerBarrier::SetMinimumDistanceBetweenNodes(double MinDistance)
+{
+	check(HasNative());
+	const double MinDistanceAGX = ConvertDistanceToAGX(MinDistance);
+	NativePtr->NativeWire->getParameterController()->setMinimumDistanceBetweenNodes(MinDistanceAGX);
+}
+
+double FWireParameterControllerBarrier::GetMinimumDistanceBetweenNodes() const
+{
+	check(HasNative());
+	const double MinDistanceAGX =
+		NativePtr->NativeWire->getParameterController()->getMinimumDistanceBetweenNodes();
+	const double MinDistance = ConvertDistanceToUnreal<double>(MinDistanceAGX);
+	return MinDistance;
 }
 
 void FWireParameterControllerBarrier::SetScaleConstant(double ScaleConstant)

--- a/Source/AGXUnrealBarrier/Private/Wire/WireParameterControllerBarrier.cpp
+++ b/Source/AGXUnrealBarrier/Private/Wire/WireParameterControllerBarrier.cpp
@@ -118,6 +118,18 @@ double FWireParameterControllerBarrier::GetSplitTensionMultiplier() const
 	return NativePtr->NativeWire->getParameterController()->getSplitTensionMultiplier();
 }
 
+void FWireParameterControllerBarrier::SetStopNodeLumpMinDistanceFraction(double Fraction)
+{
+	check(HasNative());
+	NativePtr->NativeWire->getParameterController()->setStopNodeLumpMinDistanceFraction(Fraction);
+}
+
+double FWireParameterControllerBarrier::GetStopNodeLumpMinDistanceFraction() const
+{
+	check(HasNative());
+	return NativePtr->NativeWire->getParameterController()->getStopNodeLumpMinDistanceFraction();
+}
+
 bool FWireParameterControllerBarrier::HasNative() const
 {
 	return NativePtr->NativeWire != nullptr;

--- a/Source/AGXUnrealBarrier/Private/Wire/WireParameterControllerBarrier.cpp
+++ b/Source/AGXUnrealBarrier/Private/Wire/WireParameterControllerBarrier.cpp
@@ -3,8 +3,8 @@
 #include "Wire/WireParameterControllerBarrier.h"
 
 // AGX Dynamics for Unreal includes.
-#include "AGX_LogCategory.h"
 #include "BarrierOnly/Wire/WireParameterControllerPtr.h"
+#include "TypeConversions.h"
 
 FWireParameterControllerBarrier::FWireParameterControllerBarrier()
 	: NativePtr {new FWireParameterControllerPtr()}
@@ -40,6 +40,23 @@ FWireParameterControllerBarrier& FWireParameterControllerBarrier::operator=(
 {
 	*NativePtr = *Other.NativePtr;
 	return *this;
+}
+
+void FWireParameterControllerBarrier::SetMaximumContactMovementOneTimestep(double MaxMovement)
+{
+	check(HasNative());
+	const double MaxMovementAgx = ConvertDistanceToAGX(MaxMovement);
+	NativePtr->NativeWire->getParameterController()->setMaximumContactMovementOneTimestep(
+		MaxMovementAgx);
+}
+
+double FWireParameterControllerBarrier::GetMaximumContactMovementOneTimestep() const
+{
+	check(HasNative());
+	const double MaxMovementAgx =
+		NativePtr->NativeWire->getParameterController()->getMaximumContactMovementOneTimestep();
+	const double MaxMovement = ConvertDistanceToUnreal<double>(MaxMovementAgx);
+	return MaxMovement;
 }
 
 void FWireParameterControllerBarrier::SetScaleConstant(double ScaleConstant)

--- a/Source/AGXUnrealBarrier/Public/BarrierOnly/Wire/WireParameterControllerPtr.h
+++ b/Source/AGXUnrealBarrier/Public/BarrierOnly/Wire/WireParameterControllerPtr.h
@@ -1,0 +1,20 @@
+// Copyright 2024, Algoryx Simulation AB.
+
+#pragma once
+
+#include "BeginAGXIncludes.h"
+#include <agxWire/Wire.h>
+#include <agxWire/WireParameterController.h>
+#include "EndAGXIncludes.h"
+
+struct FWireParameterControllerPtr
+{
+	// The AGX Dynamics Wire that owns the WireParameterController
+	agxWire::WireObserver NativeWire {nullptr};
+
+	FWireParameterControllerPtr() = default;
+	FWireParameterControllerPtr(agxWire::Wire* InNative)
+		: NativeWire(InNative)
+	{
+	}
+};

--- a/Source/AGXUnrealBarrier/Public/Utilities/AGX_BarrierUtilities.h
+++ b/Source/AGXUnrealBarrier/Public/Utilities/AGX_BarrierUtilities.h
@@ -1,0 +1,31 @@
+// Copyright 2024, Algoryx Simulation AB.
+
+#pragma once
+
+#define AGX_BARRIER_SET_PROPERTY(PropertyName)             \
+	if (HasNative())                                       \
+	{                                                      \
+		NativeBarrier.Set##PropertyName(In##PropertyName); \
+	}                                                      \
+	PropertyName = In##PropertyName;
+
+#define AGX_BARRIER_GET_PROPERTY(PropertyName)    \
+	if (HasNative())                              \
+	{                                             \
+		return NativeBarrier.Get##PropertyName(); \
+	}                                             \
+	else                                          \
+	{                                             \
+		return PropertyName;                      \
+	}
+
+#define AGX_BARRIER_SET_GET_PROPERTY(ClassName, PropertyType, PropertyName) \
+	void ClassName::Set##PropertyName(PropertyType In##PropertyName)        \
+	{                                                                       \
+		AGX_BARRIER_SET_PROPERTY(PropertyName);                             \
+	}                                                                       \
+                                                                            \
+	PropertyType ClassName::Get##PropertyName() const                       \
+	{                                                                       \
+		AGX_BARRIER_GET_PROPERTY(PropertyName);                             \
+	}

--- a/Source/AGXUnrealBarrier/Public/Wire/WireBarrier.h
+++ b/Source/AGXUnrealBarrier/Public/Wire/WireBarrier.h
@@ -12,6 +12,7 @@ class FShapeMaterialBarrier;
 struct FWireRef;
 class FWireNodeBarrier;
 class FWireWinchBarrier;
+class FWireParameterControllerBarrier;
 
 class AGXUNREALBARRIER_API FWireBarrier
 {
@@ -85,6 +86,8 @@ public:
 
 	/** Get the tension at the begin side of the wire [N] */
 	double GetTension() const;
+
+	FWireParameterControllerBarrier GetParameterController() const;
 
 	/**
 	 * Attach a winch to a free end of this wire.

--- a/Source/AGXUnrealBarrier/Public/Wire/WireParameterControllerBarrier.h
+++ b/Source/AGXUnrealBarrier/Public/Wire/WireParameterControllerBarrier.h
@@ -26,6 +26,9 @@ public:
 	void SetMinimumDistanceBetweenNodes(double MinDistance);
 	double GetMinimumDistanceBetweenNodes() const;
 
+	void SetRadiusMultiplier(double RadiusMultiplier);
+	double GetRadiusMultiplier() const;
+
 	void SetScaleConstant(double ScaleConstant);
 	double GetScaleConstant() const;
 

--- a/Source/AGXUnrealBarrier/Public/Wire/WireParameterControllerBarrier.h
+++ b/Source/AGXUnrealBarrier/Public/Wire/WireParameterControllerBarrier.h
@@ -20,6 +20,9 @@ public:
 	~FWireParameterControllerBarrier();
 	FWireParameterControllerBarrier& operator=(const FWireParameterControllerBarrier& Other);
 
+	void SetMaximumContactMovementOneTimestep(double MaxMovement);
+	double GetMaximumContactMovementOneTimestep() const;
+
 	void SetScaleConstant(double ScaleConstant);
 	double GetScaleConstant() const;
 

--- a/Source/AGXUnrealBarrier/Public/Wire/WireParameterControllerBarrier.h
+++ b/Source/AGXUnrealBarrier/Public/Wire/WireParameterControllerBarrier.h
@@ -1,0 +1,30 @@
+// Copyright 2024, Algoryx Simulation AB.
+
+#pragma once
+
+// Unreal Engine includes.
+#include "CoreMinimal.h"
+
+// Standard library includes.
+#include <memory>
+
+struct FWireParameterControllerPtr;
+
+class AGXUNREALBARRIER_API FWireParameterControllerBarrier
+{
+public:
+	FWireParameterControllerBarrier();
+	explicit FWireParameterControllerBarrier(std::unique_ptr<FWireParameterControllerPtr> Native);
+	FWireParameterControllerBarrier(const FWireParameterControllerBarrier& Other);
+	FWireParameterControllerBarrier(FWireParameterControllerBarrier&& Other);
+	~FWireParameterControllerBarrier();
+	FWireParameterControllerBarrier& operator=(const FWireParameterControllerBarrier& Other);
+
+	void SetScaleConstant(double ScaleConstant);
+	double GetScaleConstant() const;
+
+	bool HasNative() const;
+
+private:
+	std::unique_ptr<FWireParameterControllerPtr> NativePtr;
+};

--- a/Source/AGXUnrealBarrier/Public/Wire/WireParameterControllerBarrier.h
+++ b/Source/AGXUnrealBarrier/Public/Wire/WireParameterControllerBarrier.h
@@ -42,6 +42,9 @@ public:
 	void SetStopNodeReferenceDistance(double Distance);
 	double GetStopNodeReferenceDistance() const;
 
+	void SetWireContactDynamicsSolverDampingScale(double Scale);
+	double GetWireContactDynamicsSolverDampingScale() const;
+
 	bool HasNative() const;
 
 private:

--- a/Source/AGXUnrealBarrier/Public/Wire/WireParameterControllerBarrier.h
+++ b/Source/AGXUnrealBarrier/Public/Wire/WireParameterControllerBarrier.h
@@ -23,6 +23,9 @@ public:
 	void SetMaximumContactMovementOneTimestep(double MaxMovement);
 	double GetMaximumContactMovementOneTimestep() const;
 
+	void SetMinimumDistanceBetweenNodes(double MinDistance);
+	double GetMinimumDistanceBetweenNodes() const;
+
 	void SetScaleConstant(double ScaleConstant);
 	double GetScaleConstant() const;
 

--- a/Source/AGXUnrealBarrier/Public/Wire/WireParameterControllerBarrier.h
+++ b/Source/AGXUnrealBarrier/Public/Wire/WireParameterControllerBarrier.h
@@ -33,6 +33,9 @@ public:
 	void SetScaleConstant(double ScaleConstant);
 	double GetScaleConstant() const;
 
+	void SetSplitTensionMultiplier(double Multiplier);
+	double GetSplitTensionMultiplier() const;
+
 	bool HasNative() const;
 
 private:

--- a/Source/AGXUnrealBarrier/Public/Wire/WireParameterControllerBarrier.h
+++ b/Source/AGXUnrealBarrier/Public/Wire/WireParameterControllerBarrier.h
@@ -36,6 +36,9 @@ public:
 	void SetSplitTensionMultiplier(double Multiplier);
 	double GetSplitTensionMultiplier() const;
 
+	void SetStopNodeLumpMinDistanceFraction(double Fraction);
+	double GetStopNodeLumpMinDistanceFraction() const;
+
 	bool HasNative() const;
 
 private:

--- a/Source/AGXUnrealBarrier/Public/Wire/WireParameterControllerBarrier.h
+++ b/Source/AGXUnrealBarrier/Public/Wire/WireParameterControllerBarrier.h
@@ -39,6 +39,9 @@ public:
 	void SetStopNodeLumpMinDistanceFraction(double Fraction);
 	double GetStopNodeLumpMinDistanceFraction() const;
 
+	void SetStopNodeReferenceDistance(double Distance);
+	double GetStopNodeReferenceDistance() const;
+
 	bool HasNative() const;
 
 private:

--- a/Source/AGXUnrealBarrier/Public/Wire/WireParameterControllerBarrier.h
+++ b/Source/AGXUnrealBarrier/Public/Wire/WireParameterControllerBarrier.h
@@ -28,6 +28,7 @@ public:
 
 	void SetRadiusMultiplier(double RadiusMultiplier);
 	double GetRadiusMultiplier() const;
+	double GetScaledRadiusMultiplier(double WireRadius) const;
 
 	void SetScaleConstant(double ScaleConstant);
 	double GetScaleConstant() const;


### PR DESCRIPTION
Expose Wire Parameter Controller to Unreal.

It is a small helper-class owned by `agxWire::Wire` that contains additional parameters. It has been exposed to Unreal in the form of a struct with properties and getter/setter functions that operate very similarly to other AGX Dynamics wrapping types, with the difference being that instead of owning the Wire Parameter Controller directly, this Barrier has an observer pointer to the AGX Dynamics wire that owns the native Wire Parameter Controller. Since it is the Wire Component that owns the data from Unreal's point of view, it is that class that is responsible for propagating Details panel changes via the Property Dispatcher and for setting the native after a Blueprint Reconstruction.