### PR TITLE
fix/terrain-material-copy

### DIFF
--- a/Source/AGXUnreal/Private/Materials/AGX_TerrainMaterial.cpp
+++ b/Source/AGXUnreal/Private/Materials/AGX_TerrainMaterial.cpp
@@ -518,6 +518,7 @@ void UAGX_TerrainMaterial::Serialize(FArchive& Archive)
 
 void UAGX_TerrainMaterial::CopyFrom(const FTerrainMaterialBarrier& Source)
 {
+	// Copy Bulk properties.
 	TerrainBulk = FAGX_TerrainBulkProperties();
 	TerrainBulk.AdhesionOverlapFactor = Source.GetAdhesionOverlapFactor();
 	TerrainBulk.Cohesion = Source.GetCohesion();
@@ -529,6 +530,7 @@ void UAGX_TerrainMaterial::CopyFrom(const FTerrainMaterialBarrier& Source)
 	TerrainBulk.SwellFactor = Source.GetSwellFactor();
 	TerrainBulk.YoungsModulus = Source.GetYoungsModulus();
 
+	// Copy Compaction properties.
 	TerrainCompaction = FAGX_TerrainCompactionProperties();
 	TerrainCompaction.AngleOfReposeCompactionRate = Source.GetAngleOfReposeCompactionRate();
 	TerrainCompaction.BankStatePhi0 = Source.GetBankStatePhi();
@@ -541,6 +543,7 @@ void UAGX_TerrainMaterial::CopyFrom(const FTerrainMaterialBarrier& Source)
 	TerrainCompaction.StressCutOffFraction = Source.GetStressCutOffFraction();
 	TerrainCompaction.DilatancyAngleScalingFactor = Source.GetDilatancyAngleScalingFactor();
 
+	// Copy Particle properties.
 	TerrainParticles = FAGX_TerrainParticleProperties();
 	TerrainParticles.AdhesionOverlapFactor = Source.GetParticleAdhesionOverlapFactor();
 	TerrainParticles.ParticleCohesion = Source.GetParticleCohesion();
@@ -555,6 +558,7 @@ void UAGX_TerrainMaterial::CopyFrom(const FTerrainMaterialBarrier& Source)
 	TerrainParticles.ParticleTerrainYoungsModulus = Source.GetParticleTerrainYoungsModulus();
 	TerrainParticles.ParticleYoungsModulus = Source.GetParticleYoungsModulus();
 
+	// Copy Excavation properties.
 	TerrainExcavationContact = FAGX_TerrainExcavationContactProperties();
 	TerrainExcavationContact.AggregateStiffnessMultiplier =
 		Source.GetAggregateStiffnessMultiplier();
@@ -570,13 +574,14 @@ void UAGX_TerrainMaterial::CopyTerrainMaterialProperties(const UAGX_TerrainMater
 {
 	if (Source)
 	{
-		// As of now, this property is not used for terrain (replaced by the terrain specific bulk
-		// properties) and will always have default values.
-		Bulk = Source->Bulk;
-
-		Surface = Source->Surface;
 		TerrainBulk = Source->TerrainBulk;
 		TerrainCompaction = Source->TerrainCompaction;
+
+		// The rest of the properties are legacy and should not be used. Still copied to maintain
+		// consistency, and to keep our unit tests passing.
+		Bulk = Source->Bulk;
+		Surface = Source->Surface;
+		Wire = Source->Wire;
 	}
 }
 

--- a/Source/AGXUnreal/Private/Materials/AGX_TerrainMaterial.cpp
+++ b/Source/AGXUnreal/Private/Materials/AGX_TerrainMaterial.cpp
@@ -899,7 +899,6 @@ bool UAGX_TerrainMaterial::HasTerrainMaterialNative() const
 	return TerrainMaterialNativeBarrier.HasNative();
 }
 
-
 UAGX_TerrainMaterial* UAGX_TerrainMaterial::CreateFromAsset(
 	UWorld* PlayingWorld, UAGX_TerrainMaterial* Source)
 {
@@ -1068,15 +1067,12 @@ bool UAGX_TerrainMaterial::IsInstance() const
 {
 	// An instance of this class will always have a reference to it's corresponding Asset.
 	// An asset will never have this reference set.
-	const bool bIsInstance = Asset != nullptr;
-
-	// Internal testing the hypothesis that UObject::IsAsset is a valid inverse of this
-	// function.
-	// @todo Consider removing this function and instead use UObject::IsAsset, if the below
-	// check has never failed.
-	AGX_CHECK(bIsInstance != IsAsset());
-
-	return bIsInstance;
+	//
+	// Cannot use a negated return value from IsAsset because sometimes we create runtime instances
+	// that we want to use as-if they are assets without actually creating real on-drive assets,
+	// and difficult to fool the IsAsset function into believing that something is an asset when it
+	// actually is not.
+	return Asset != nullptr;
 }
 
 const FAGX_ShapeMaterialBulkProperties& UAGX_TerrainMaterial::GetShapeMaterialBulkProperties()

--- a/Source/AGXUnreal/Private/Materials/AGX_TerrainMaterial.cpp
+++ b/Source/AGXUnreal/Private/Materials/AGX_TerrainMaterial.cpp
@@ -516,92 +516,6 @@ void UAGX_TerrainMaterial::Serialize(FArchive& Archive)
 	TerrainCompaction.Serialize(Archive);
 }
 
-void UAGX_TerrainMaterial::CopyFrom(const FTerrainMaterialBarrier& Source)
-{
-	// Copy Bulk properties.
-	TerrainBulk = FAGX_TerrainBulkProperties();
-	TerrainBulk.AdhesionOverlapFactor = Source.GetAdhesionOverlapFactor();
-	TerrainBulk.Cohesion = Source.GetCohesion();
-	TerrainBulk.Density = Source.GetDensity();
-	TerrainBulk.DilatancyAngle = Source.GetDilatancyAngle();
-	TerrainBulk.FrictionAngle = Source.GetFrictionAngle();
-	TerrainBulk.MaxDensity = Source.GetMaxDensity();
-	TerrainBulk.PoissonsRatio = Source.GetPoissonsRatio();
-	TerrainBulk.SwellFactor = Source.GetSwellFactor();
-	TerrainBulk.YoungsModulus = Source.GetYoungsModulus();
-
-	// Copy Compaction properties.
-	TerrainCompaction = FAGX_TerrainCompactionProperties();
-	TerrainCompaction.AngleOfReposeCompactionRate = Source.GetAngleOfReposeCompactionRate();
-	TerrainCompaction.BankStatePhi0 = Source.GetBankStatePhi();
-	TerrainCompaction.CompactionTimeRelaxationConstant =
-		Source.GetCompactionTimeRelaxationConstant();
-	TerrainCompaction.CompressionIndex = Source.GetCompressionIndex();
-	TerrainCompaction.HardeningConstantKe = Source.GetHardeningConstantKe();
-	TerrainCompaction.HardeningConstantNe = Source.GetHardeningConstantNe();
-	TerrainCompaction.PreconsolidationStress = Source.GetPreconsolidationStress();
-	TerrainCompaction.StressCutOffFraction = Source.GetStressCutOffFraction();
-	TerrainCompaction.DilatancyAngleScalingFactor = Source.GetDilatancyAngleScalingFactor();
-
-	// Copy Particle properties.
-	TerrainParticles = FAGX_TerrainParticleProperties();
-	TerrainParticles.AdhesionOverlapFactor = Source.GetParticleAdhesionOverlapFactor();
-	TerrainParticles.ParticleCohesion = Source.GetParticleCohesion();
-	TerrainParticles.ParticleRestitution = Source.GetParticleRestitution();
-	TerrainParticles.ParticleRollingResistance = Source.GetParticleRollingResistance();
-	TerrainParticles.ParticleSurfaceFriction = Source.GetParticleSurfaceFriction();
-	TerrainParticles.ParticleTerrainCohesion = Source.GetParticleTerrainCohesion();
-	TerrainParticles.ParticleTerrainRestitution = Source.GetParticleTerrainRestitution();
-	TerrainParticles.ParticleTerrainRollingResistance =
-		Source.GetParticleTerrainRollingResistance();
-	TerrainParticles.ParticleTerrainSurfaceFriction = Source.GetParticleTerrainSurfaceFriction();
-	TerrainParticles.ParticleTerrainYoungsModulus = Source.GetParticleTerrainYoungsModulus();
-	TerrainParticles.ParticleYoungsModulus = Source.GetParticleYoungsModulus();
-
-	// Copy Excavation properties.
-	TerrainExcavationContact = FAGX_TerrainExcavationContactProperties();
-	TerrainExcavationContact.AggregateStiffnessMultiplier =
-		Source.GetAggregateStiffnessMultiplier();
-	TerrainExcavationContact.ExcavationStiffnessMultiplier =
-		Source.GetExcavationStiffnessMultiplier();
-	TerrainExcavationContact.DepthDecayFactor = Source.GetDepthDecayFactor();
-	TerrainExcavationContact.DepthIncreaseFactor = Source.GetDepthIncreaseFactor();
-	TerrainExcavationContact.MaximumAggregateNormalForce = Source.GetMaximumAggregateNormalForce();
-	TerrainExcavationContact.MaximumContactDepth = Source.GetMaximumContactDepth();
-}
-
-void UAGX_TerrainMaterial::CopyTerrainMaterialProperties(const UAGX_TerrainMaterial* Source)
-{
-	if (Source)
-	{
-		TerrainBulk = Source->TerrainBulk;
-		TerrainCompaction = Source->TerrainCompaction;
-
-		// The rest of the properties are legacy and should not be used. Still copied to maintain
-		// consistency, and to keep our unit tests passing.
-		Bulk = Source->Bulk;
-		Surface = Source->Surface;
-		Wire = Source->Wire;
-	}
-}
-
-UAGX_TerrainMaterial* UAGX_TerrainMaterial::GetOrCreateInstance(UWorld* PlayingWorld)
-{
-	if (IsInstance())
-	{
-		return this;
-	}
-
-	UAGX_TerrainMaterial* InstancePtr = Instance.Get();
-	if (!InstancePtr && PlayingWorld && PlayingWorld->IsGameWorld())
-	{
-		InstancePtr = UAGX_TerrainMaterial::CreateFromAsset(PlayingWorld, this);
-		Instance = InstancePtr;
-	}
-
-	return InstancePtr;
-}
-
 #if WITH_EDITOR
 void UAGX_TerrainMaterial::PostEditChangeChainProperty(FPropertyChangedChainEvent& Event)
 {
@@ -947,6 +861,45 @@ FTerrainMaterialBarrier* UAGX_TerrainMaterial::GetOrCreateTerrainMaterialNative(
 	return GetTerrainMaterialNative();
 }
 
+FTerrainMaterialBarrier* UAGX_TerrainMaterial::GetTerrainMaterialNative()
+{
+	return HasTerrainMaterialNative() ? &TerrainMaterialNativeBarrier : nullptr;
+}
+
+UAGX_TerrainMaterial* UAGX_TerrainMaterial::GetOrCreateInstance(UWorld* PlayingWorld)
+{
+	if (IsInstance())
+	{
+		return this;
+	}
+
+	UAGX_TerrainMaterial* InstancePtr = Instance.Get();
+	if (!InstancePtr && PlayingWorld && PlayingWorld->IsGameWorld())
+	{
+		InstancePtr = UAGX_TerrainMaterial::CreateFromAsset(PlayingWorld, this);
+		Instance = InstancePtr;
+	}
+
+	return InstancePtr;
+}
+
+bool UAGX_TerrainMaterial::HasTerrainMaterialNative() const
+{
+	if (!IsInstance())
+	{
+		if (Instance == nullptr)
+		{
+			return false;
+		}
+
+		return Instance->HasTerrainMaterialNative();
+	}
+
+	AGX_CHECK(IsInstance());
+	return TerrainMaterialNativeBarrier.HasNative();
+}
+
+
 UAGX_TerrainMaterial* UAGX_TerrainMaterial::CreateFromAsset(
 	UWorld* PlayingWorld, UAGX_TerrainMaterial* Source)
 {
@@ -969,56 +922,21 @@ UAGX_TerrainMaterial* UAGX_TerrainMaterial::CreateFromAsset(
 	return NewInstance;
 }
 
-void UAGX_TerrainMaterial::CreateTerrainMaterialNative()
+void UAGX_TerrainMaterial::CopyTerrainMaterialProperties(const UAGX_TerrainMaterial* Source)
 {
-	if (!IsInstance())
+	if (Source)
 	{
-		if (Instance == nullptr)
-		{
-			UE_LOG(
-				LogAGX, Error,
-				TEXT("CreateTerrainMaterialNative was called on UAGX_TerrainMaterial '%s'"
-					 "who's instance is nullptr. Ensure e.g. GetOrCreateInstance is called "
-					 "prior to calling this function."),
-				*GetName());
-			return;
-		}
+		TerrainBulk = Source->TerrainBulk;
+		TerrainCompaction = Source->TerrainCompaction;
+		TerrainParticles = Source->TerrainParticles;
+		TerrainExcavationContact = Source->TerrainExcavationContact;
 
-		Instance->CreateTerrainMaterialNative();
-		return;
+		// The rest of the properties are legacy and should not be used. Still copied to maintain
+		// consistency, and to keep our unit tests passing.
+		Bulk = Source->Bulk;
+		Surface = Source->Surface;
+		Wire = Source->Wire;
 	}
-
-	AGX_CHECK(IsInstance());
-	if (TerrainMaterialNativeBarrier.HasNative())
-	{
-		TerrainMaterialNativeBarrier.ReleaseNative();
-	}
-
-	TerrainMaterialNativeBarrier.AllocateNative(TCHAR_TO_UTF8(*GetName()));
-	check(HasTerrainMaterialNative());
-
-	UpdateTerrainMaterialNativeProperties();
-}
-
-bool UAGX_TerrainMaterial::HasTerrainMaterialNative() const
-{
-	if (!IsInstance())
-	{
-		if (Instance == nullptr)
-		{
-			return false;
-		}
-
-		return Instance->HasTerrainMaterialNative();
-	}
-
-	AGX_CHECK(IsInstance());
-	return TerrainMaterialNativeBarrier.HasNative();
-}
-
-FTerrainMaterialBarrier* UAGX_TerrainMaterial::GetTerrainMaterialNative()
-{
-	return HasTerrainMaterialNative() ? &TerrainMaterialNativeBarrier : nullptr;
 }
 
 void UAGX_TerrainMaterial::UpdateTerrainMaterialNativeProperties()
@@ -1092,6 +1010,60 @@ void UAGX_TerrainMaterial::UpdateTerrainMaterialNativeProperties()
 	}
 }
 
+void UAGX_TerrainMaterial::CopyFrom(const FTerrainMaterialBarrier& Source)
+{
+	// Copy Bulk properties.
+	TerrainBulk = FAGX_TerrainBulkProperties();
+	TerrainBulk.AdhesionOverlapFactor = Source.GetAdhesionOverlapFactor();
+	TerrainBulk.Cohesion = Source.GetCohesion();
+	TerrainBulk.Density = Source.GetDensity();
+	TerrainBulk.DilatancyAngle = Source.GetDilatancyAngle();
+	TerrainBulk.FrictionAngle = Source.GetFrictionAngle();
+	TerrainBulk.MaxDensity = Source.GetMaxDensity();
+	TerrainBulk.PoissonsRatio = Source.GetPoissonsRatio();
+	TerrainBulk.SwellFactor = Source.GetSwellFactor();
+	TerrainBulk.YoungsModulus = Source.GetYoungsModulus();
+
+	// Copy Compaction properties.
+	TerrainCompaction = FAGX_TerrainCompactionProperties();
+	TerrainCompaction.AngleOfReposeCompactionRate = Source.GetAngleOfReposeCompactionRate();
+	TerrainCompaction.BankStatePhi0 = Source.GetBankStatePhi();
+	TerrainCompaction.CompactionTimeRelaxationConstant =
+		Source.GetCompactionTimeRelaxationConstant();
+	TerrainCompaction.CompressionIndex = Source.GetCompressionIndex();
+	TerrainCompaction.HardeningConstantKe = Source.GetHardeningConstantKe();
+	TerrainCompaction.HardeningConstantNe = Source.GetHardeningConstantNe();
+	TerrainCompaction.PreconsolidationStress = Source.GetPreconsolidationStress();
+	TerrainCompaction.StressCutOffFraction = Source.GetStressCutOffFraction();
+	TerrainCompaction.DilatancyAngleScalingFactor = Source.GetDilatancyAngleScalingFactor();
+
+	// Copy Particle properties.
+	TerrainParticles = FAGX_TerrainParticleProperties();
+	TerrainParticles.AdhesionOverlapFactor = Source.GetParticleAdhesionOverlapFactor();
+	TerrainParticles.ParticleCohesion = Source.GetParticleCohesion();
+	TerrainParticles.ParticleRestitution = Source.GetParticleRestitution();
+	TerrainParticles.ParticleRollingResistance = Source.GetParticleRollingResistance();
+	TerrainParticles.ParticleSurfaceFriction = Source.GetParticleSurfaceFriction();
+	TerrainParticles.ParticleTerrainCohesion = Source.GetParticleTerrainCohesion();
+	TerrainParticles.ParticleTerrainRestitution = Source.GetParticleTerrainRestitution();
+	TerrainParticles.ParticleTerrainRollingResistance =
+		Source.GetParticleTerrainRollingResistance();
+	TerrainParticles.ParticleTerrainSurfaceFriction = Source.GetParticleTerrainSurfaceFriction();
+	TerrainParticles.ParticleTerrainYoungsModulus = Source.GetParticleTerrainYoungsModulus();
+	TerrainParticles.ParticleYoungsModulus = Source.GetParticleYoungsModulus();
+
+	// Copy Excavation properties.
+	TerrainExcavationContact = FAGX_TerrainExcavationContactProperties();
+	TerrainExcavationContact.AggregateStiffnessMultiplier =
+		Source.GetAggregateStiffnessMultiplier();
+	TerrainExcavationContact.ExcavationStiffnessMultiplier =
+		Source.GetExcavationStiffnessMultiplier();
+	TerrainExcavationContact.DepthDecayFactor = Source.GetDepthDecayFactor();
+	TerrainExcavationContact.DepthIncreaseFactor = Source.GetDepthIncreaseFactor();
+	TerrainExcavationContact.MaximumAggregateNormalForce = Source.GetMaximumAggregateNormalForce();
+	TerrainExcavationContact.MaximumContactDepth = Source.GetMaximumContactDepth();
+}
+
 bool UAGX_TerrainMaterial::IsInstance() const
 {
 	// An instance of this class will always have a reference to it's corresponding Asset.
@@ -1120,4 +1092,35 @@ const FAGX_ShapeMaterialSurfaceProperties& UAGX_TerrainMaterial::GetShapeMateria
 const FAGX_ShapeMaterialWireProperties& UAGX_TerrainMaterial::GetShapeMaterialWireProperties()
 {
 	return Wire;
+}
+
+void UAGX_TerrainMaterial::CreateTerrainMaterialNative()
+{
+	if (!IsInstance())
+	{
+		if (Instance == nullptr)
+		{
+			UE_LOG(
+				LogAGX, Error,
+				TEXT("CreateTerrainMaterialNative was called on UAGX_TerrainMaterial '%s'"
+					 "who's instance is nullptr. Ensure e.g. GetOrCreateInstance is called "
+					 "prior to calling this function."),
+				*GetName());
+			return;
+		}
+
+		Instance->CreateTerrainMaterialNative();
+		return;
+	}
+
+	AGX_CHECK(IsInstance());
+	if (TerrainMaterialNativeBarrier.HasNative())
+	{
+		TerrainMaterialNativeBarrier.ReleaseNative();
+	}
+
+	TerrainMaterialNativeBarrier.AllocateNative(TCHAR_TO_UTF8(*GetName()));
+	check(HasTerrainMaterialNative());
+
+	UpdateTerrainMaterialNativeProperties();
 }

--- a/Source/AGXUnreal/Public/Materials/AGX_TerrainBulkProperties.h
+++ b/Source/AGXUnreal/Public/Materials/AGX_TerrainBulkProperties.h
@@ -22,6 +22,9 @@ public:
 	/**
 	 * Sets the adhesion overlap factor of the bulk material, i.e what fraction of the particle
 	 * radius is allowed to overlap to simulate adhesion.
+	 *
+	 * As of AGX Dynamics versions 2.29 this property is deprecated. The the property with the same
+	 * name in Terrain Particle Properties instead.
 	 */
 	UPROPERTY(
 		EditAnywhere, Category = "AGX Terrain Material Bulk",

--- a/Source/AGXUnreal/Public/Materials/AGX_TerrainMaterial.h
+++ b/Source/AGXUnreal/Public/Materials/AGX_TerrainMaterial.h
@@ -279,14 +279,16 @@ public:
 
 	virtual void Serialize(FArchive& Archive) override;
 
-	void CopyFrom(const FTerrainMaterialBarrier& Source);
-
 	FTerrainMaterialBarrier* GetOrCreateTerrainMaterialNative(UWorld* PlayingWorld);
+	FTerrainMaterialBarrier* GetTerrainMaterialNative();
 	UAGX_TerrainMaterial* GetOrCreateInstance(UWorld* PlayingWorld);
+	bool HasTerrainMaterialNative() const;
 	static UAGX_TerrainMaterial* CreateFromAsset(
 		UWorld* PlayingWorld, UAGX_TerrainMaterial* Source);
 
 	void CopyTerrainMaterialProperties(const UAGX_TerrainMaterial* Source);
+	void UpdateTerrainMaterialNativeProperties();
+	void CopyFrom(const FTerrainMaterialBarrier& Source);
 
 	bool IsInstance() const;
 
@@ -302,9 +304,6 @@ private:
 #endif
 
 	void CreateTerrainMaterialNative();
-	bool HasTerrainMaterialNative() const;
-	FTerrainMaterialBarrier* GetTerrainMaterialNative();
-	void UpdateTerrainMaterialNativeProperties();
 
 	TWeakObjectPtr<UAGX_TerrainMaterial> Asset;
 	TWeakObjectPtr<UAGX_TerrainMaterial> Instance;

--- a/Source/AGXUnrealTests/Private/AGX_TerrainMaterial.spec.cpp
+++ b/Source/AGXUnrealTests/Private/AGX_TerrainMaterial.spec.cpp
@@ -27,6 +27,8 @@ namespace AGX_TerrainMaterialSpec_helpers
 	 *
 	 * Visits nested struct properties recursively.
 	 *
+	 * Currently does not handle container properties such as arrays, maps, and sets.
+	 *
 	 * @param StructProperty Reflection data for the struct whose properties are being visited.
 	 * @param StructMemory Pointer to the struct described by StructProperty.
 	 * @param CPPType The name of the type that the callback should be called for.
@@ -61,6 +63,8 @@ namespace AGX_TerrainMaterialSpec_helpers
 	 * Run a callback for every non-deprecated property of the given CPPType in the given object.
 	 *
 	 * Visits nested struct properties recursively.
+	 *
+	 * Currently does not handle container properties such as arrays, maps, and sets.
 	 *
 	 * @param Object The object whose properties are to be visited.
 	 * @param CPPType The name of the type that the callback should be called for.

--- a/Source/AGXUnrealTests/Private/AGX_TerrainMaterial.spec.cpp
+++ b/Source/AGXUnrealTests/Private/AGX_TerrainMaterial.spec.cpp
@@ -76,42 +76,6 @@ namespace AGX_TerrainMaterialSpec_helpers
 		}
 	}
 
-	double SetAllRealPropertiesToIncreasingValues(
-		double NextValue, FStructProperty* StructProperty, void* StructMemory)
-	{
-		// Loop over AdhesionOverlapFactor, Cohesion, Density, etc.
-		UScriptStruct* Struct = StructProperty->Struct;
-		for (TFieldIterator<FProperty> PropertyIt(Struct); PropertyIt; ++PropertyIt)
-		{
-			FProperty* Property = *PropertyIt;
-			UE_LOG(LogAGX, Warning, TEXT("  Found property of type %s"), *Property->GetCPPType());
-			if (FStructProperty* NestedStructProperty = CastField<FStructProperty>(Property))
-			{
-				UE_LOG(
-					LogAGX, Warning, TEXT("  Found nested struct of type %s."),
-					*NestedStructProperty->Struct->GetName());
-				void* PropertyMemory = Property->ContainerPtrToValuePtr<void>(StructMemory);
-				if (NestedStructProperty->Struct == FAGX_Real::StaticStruct())
-				{
-					UE_LOG(
-						LogAGX, Warning, TEXT("    Found FAGX_Real struct, writing %f."),
-						NextValue);
-					FAGX_Real* Real = static_cast<FAGX_Real*>(PropertyMemory);
-					Real->Value = NextValue;
-					NextValue += 1.0;
-				}
-				else
-				{
-					UE_LOG(LogAGX, Warning, TEXT("Is a struct, recursion."));
-					NextValue = SetAllRealPropertiesToIncreasingValues(
-						NextValue, NestedStructProperty, PropertyMemory);
-				}
-			}
-		}
-
-		return NextValue;
-	}
-
 	void SetAllRealPropertiesToIncreasingValues(UObject* Object)
 	{
 		auto Callback = [NextValue = 0.0](void* Memory, const TCHAR* /*Name*/) mutable

--- a/Source/AGXUnrealTests/Private/AGX_TerrainMaterial.spec.cpp
+++ b/Source/AGXUnrealTests/Private/AGX_TerrainMaterial.spec.cpp
@@ -1,0 +1,263 @@
+// Copyright 2024, Algoryx Simulation AB.
+
+// AGX Dynamics for Unreal includes.
+#include "AGX_LogCategory.h"
+#include "AgxAutomationCommon.h"
+#include "Materials/AGX_TerrainMaterial.h"
+
+// Unreal Engine includes.
+#include "CoreMinimal.h"
+#include "Misc/AutomationTest.h"
+#include "UObject/UnrealType.h"
+
+BEGIN_DEFINE_SPEC(
+	FAGX_TerrainMaterialSpec, "AGXUnreal.Spec.TerrainMaterial",
+	AgxAutomationCommon::DefaultTestFlags)
+END_DEFINE_SPEC(FAGX_TerrainMaterialSpec)
+
+namespace AGX_TerrainMaterialSpec_helpers
+{
+	template <typename CallbackT>
+	void VisitProperties(
+		FStructProperty* StructProperty, void* StructMemory, const FString& CPPType,
+		CallbackT& Callback)
+	{
+		UScriptStruct* Struct = StructProperty->Struct;
+		UE_LOG(
+			LogAGX, Warning, TEXT("  Visiting %s properties in %s."), *CPPType,
+			*StructProperty->GetName());
+		for (TFieldIterator<FProperty> PropertyIt(Struct); PropertyIt; ++PropertyIt)
+		{
+			FProperty* Property = *PropertyIt;
+			UE_LOG(
+				LogAGX, Warning, TEXT("Found property named %s of type %s."), *Property->GetName(),
+				*Property->GetCPPType());
+			void* PropertyMemory = Property->ContainerPtrToValuePtr<void>(StructMemory);
+			if (Property->GetCPPType() == CPPType)
+			{
+				Callback(PropertyMemory);
+			}
+			else if (FStructProperty* NestedStructProperty = CastField<FStructProperty>(Property))
+			{
+				VisitProperties(NestedStructProperty, PropertyMemory, CPPType, Callback);
+			}
+		}
+	}
+
+	template <typename CallbackT>
+	void VisitProperties(UObject* Object, const FString& CPPType, CallbackT& Callback)
+	{
+		UClass* Class = Object->GetClass();
+		UE_LOG(
+			LogAGX, Warning, TEXT("Visiting %s properties in %s."), *CPPType, *Object->GetName());
+		for (TFieldIterator<FProperty> PropertyIt(Class); PropertyIt; ++PropertyIt)
+		{
+			FProperty* Property = *PropertyIt;
+			UE_LOG(
+				LogAGX, Warning, TEXT("Found property named %s of type %s."), *Property->GetName(),
+				*Property->GetCPPType());
+			void* PropertyMemory = Property->ContainerPtrToValuePtr<void>(Object);
+			if (Property->GetCPPType() == CPPType)
+			{
+				Callback(PropertyMemory);
+			}
+			else if (FStructProperty* NestedStructProperty = CastField<FStructProperty>(Property))
+			{
+				VisitProperties(NestedStructProperty, PropertyMemory, CPPType, Callback);
+			}
+		}
+	}
+
+	double SetAllRealPropertiesToIncreasingValues(
+		double NextValue, FStructProperty* StructProperty, void* StructMemory)
+	{
+		// Loop over AdhesionOverlapFactor, Cohesion, Density, etc.
+		UScriptStruct* Struct = StructProperty->Struct;
+		for (TFieldIterator<FProperty> PropertyIt(Struct); PropertyIt; ++PropertyIt)
+		{
+			FProperty* Property = *PropertyIt;
+			UE_LOG(LogAGX, Warning, TEXT("  Found property of type %s"), *Property->GetCPPType());
+			if (FStructProperty* NestedStructProperty = CastField<FStructProperty>(Property))
+			{
+				UE_LOG(
+					LogAGX, Warning, TEXT("  Found nested struct of type %s."),
+					*NestedStructProperty->Struct->GetName());
+				void* PropertyMemory = Property->ContainerPtrToValuePtr<void>(StructMemory);
+				if (NestedStructProperty->Struct == FAGX_Real::StaticStruct())
+				{
+					UE_LOG(
+						LogAGX, Warning, TEXT("    Found FAGX_Real struct, writing %f."),
+						NextValue);
+					FAGX_Real* Real = static_cast<FAGX_Real*>(PropertyMemory);
+					Real->Value = NextValue;
+					NextValue += 1.0;
+				}
+				else
+				{
+					UE_LOG(LogAGX, Warning, TEXT("Is a struct, recursion."));
+					NextValue = SetAllRealPropertiesToIncreasingValues(
+						NextValue, NestedStructProperty, PropertyMemory);
+				}
+			}
+		}
+
+		return NextValue;
+	}
+
+	void SetAllRealPropertiesToIncreasingValues(UObject* Object)
+	{
+		auto Callback = [NextValue = 0.0](void* Memory) mutable
+		{
+			FAGX_Real* Real = static_cast<FAGX_Real*>(Memory);
+			UE_LOG(LogAGX, Warning, TEXT("  Overwriting %f with %f."), Real->Value, NextValue);
+			Real->Value = NextValue;
+			NextValue = NextValue + 1.0;
+		};
+
+		VisitProperties(Object, TEXT("FAGX_Real"), Callback);
+	}
+
+	void AssertAllRealPropertiesHaveIncreasingValues(UObject* Object)
+	{
+		auto Callback = [NextValue = 0.0](void* Memory) mutable
+		{
+			FAGX_Real* Real = static_cast<FAGX_Real*>(Memory);
+			UE_LOG(LogAGX, Warning, TEXT("  Expecting %f, found %f."), NextValue, Real->Value);
+			if (NextValue != Real->Value)
+			{
+				UE_LOG(LogAGX, Warning, TEXT("     MISMATCH!"));
+			}
+			NextValue = NextValue + 1.0;
+		};
+
+		VisitProperties(Object, TEXT("FAGX_Real"), Callback);
+	}
+}
+
+void FAGX_TerrainMaterialSpec::Define()
+{
+	UE_LOG(LogAGX, Warning, TEXT("Discovering FAGX_TerrainMaterialSpec"));
+	Describe(
+		"When copying properties from one Terrain Material to another",
+		[this]()
+		{
+			It("should copy all properties",
+			   [this]()
+			   {
+				   TObjectPtr<UAGX_TerrainMaterial> Source = NewObject<UAGX_TerrainMaterial>(
+					   GetTransientPackage(), TEXT("Source Terrain Material"));
+
+				   AGX_TerrainMaterialSpec_helpers::SetAllRealPropertiesToIncreasingValues(Source);
+				   AGX_TerrainMaterialSpec_helpers::AssertAllRealPropertiesHaveIncreasingValues(
+					   Source);
+
+			   	TObjectPtr<UAGX_TerrainMaterial> Destination =  NewObject<UAGX_TerrainMaterial>(GetTransientPackage(), TEXT("Destination Terrain Material"));
+			   	Destination->CopyTerrainMaterialProperties(Source);
+			   	AGX_TerrainMaterialSpec_helpers::AssertAllRealPropertiesHaveIncreasingValues(Destination);
+
+#if 0
+				   TObjectPtr<UAGX_TerrainMaterial> Destination = NewObject<UAGX_TerrainMaterial>(
+					   GetTransientPackage(), TEXT("Destination Terrain Materia."));
+
+				   UE_LOG(LogAGX, Warning, TEXT("Source: %p"), Source);
+				   UE_LOG(LogAGX, Warning, TEXT("TerrainBulk:  %p"), &Source->TerrainBulk);
+				   UE_LOG(
+					   LogAGX, Warning, TEXT("AdhesionOverlapFactor: %p"),
+					   &Source->TerrainBulk.AdhesionOverlapFactor);
+				   UE_LOG(
+					   LogAGX, Warning, TEXT("Value: %p"),
+					   &Source->TerrainBulk.AdhesionOverlapFactor.Value);
+				   UE_LOG(
+					   LogAGX, Warning, TEXT("Value: %f"),
+					   Source->TerrainBulk.AdhesionOverlapFactor.Value);
+
+				   // Loop over TerrainBulk, TerrainCompaction, etc.
+				   UClass* Class = UAGX_TerrainMaterial::StaticClass();
+				   for (TFieldIterator<FProperty> PropIt(Class); PropIt; ++PropIt)
+				   {
+					   FProperty* TerrainMaterialProperty = *PropIt;
+					   UE_LOG(
+						   LogAGX, Warning, TEXT("Got property named '%s' from owner class '%s'."),
+						   *TerrainMaterialProperty->GetName(),
+						   *TerrainMaterialProperty->GetOwnerClass()->GetName());
+
+					   FStructProperty* TerrainMaterialStructProperty =
+						   CastField<FStructProperty>(TerrainMaterialProperty);
+					   void* StructPtr =
+						   TerrainMaterialStructProperty->ContainerPtrToValuePtr<void>(Source);
+					   UE_LOG(LogAGX, Warning, TEXT("  Struct: %p"), StructPtr);
+					   UE_LOG(LogAGX, Warning, TEXT("Looping over struct members:"));
+
+#if 1
+					   // Loop over AdhesionOverlapFactor, Cohesion, Density, etc.
+					   TObjectPtr<UScriptStruct> Struct = TerrainMaterialStructProperty->Struct;
+					   for (TFieldIterator<FProperty> StructPropIt(Struct); StructPropIt;
+							++StructPropIt)
+					   {
+						   FProperty* StructMemberProperty = *StructPropIt;
+						   UE_LOG(
+							   LogAGX, Warning, TEXT("  Struct member %s"),
+							   *StructMemberProperty->GetName());
+						   void* RealStructPtr =
+							   StructPropIt->ContainerPtrToValuePtr<void>(StructPtr);
+						   UE_LOG(LogAGX, Warning, TEXT("  RealStructPtr: %p"), RealStructPtr);
+#if 1
+						   FAGX_Real* RealValue = (FAGX_Real*) RealStructPtr;
+						   UE_LOG(LogAGX, Warning, TEXT("  RealStructValue: %f"), RealValue->Value);
+						   StructMemberProperty->HasAnyPropertyFlags(CPF_Deprecated);
+
+#else
+						   FStructProperty* RealProperty =
+							   CastField<FStructProperty>(StructMemberProperty);
+						   for (TFieldIterator<FProperty> RealPropIt(RealProperty->Struct);
+								RealPropIt; ++RealPropIt)
+						   {
+							   FProperty* RealInnerProperty = *RealPropIt;
+							   UE_LOG(
+								   LogAGX, Warning, TEXT("    Real property: %s"),
+								   *RealInnerProperty->GetName());
+							   if (FDoubleProperty* DoubleProperty =
+									   CastField<FDoubleProperty>(RealInnerProperty))
+							   {
+								   UE_LOG(LogAGX, Warning, TEXT("Is a Double property."));
+								   void* StructMemory =
+									   RealInnerProperty->ContainerPtrToValuePtr<void>(Source);
+								   double DoubleValue = DoubleProperty->GetPropertyValue(
+									   RealProperty->ContainerPtrToValuePtr<void>(StructMemory));
+								   UE_LOG(LogTemp, Log, TEXT("    Double value: %f"), DoubleValue);
+							   }
+							   else
+							   {
+								   UE_LOG(
+									   LogAGX, Warning, TEXT("    Property %s has unknown type."),
+									   *RealInnerProperty->GetName());
+							   }
+						   }
+#endif
+					   }
+#else
+				for (FField* StructMember = Struct->ChildProperties; StructMember != nullptr;
+					 StructMember = StructMember->Next)
+				{
+					UE_LOG(
+						LogAGX, Warning, TEXT("  Got sub-property named '%s' of type '%s'."),
+						*StructMember->GetName(), *StructMember->GetClass()->GetName());
+
+					const FProperty* ChildProperty = nullptr;
+					const void* ChildData = nullptr;
+					TerrainMaterialStructProperty->FindInnerPropertyInstance(
+						StructMember->GetFName(), StructPtr, ChildProperty, ChildData);
+					const FAGX_Real* AsReal = reinterpret_cast<const FAGX_Real*>(ChildData);
+					UE_LOG(LogAGX, Warning, TEXT("  Has value: %d"), AsReal->Value);
+				}
+				UE_LOG(LogAGX, Warning, TEXT("No more struct members."))
+
+				// TestEqual(
+				//  TEXT("Class"), reinterpret_cast<intptr_t>(Class),
+				//  reinterpret_cast<intptr_t>(Property->GetClass()));
+#endif
+				   };
+#endif
+			   });
+		});
+}

--- a/Source/AGXUnrealTests/Private/AGX_TerrainMaterial.spec.cpp
+++ b/Source/AGXUnrealTests/Private/AGX_TerrainMaterial.spec.cpp
@@ -32,6 +32,10 @@ namespace AGX_TerrainMaterialSpec_helpers
 			UE_LOG(
 				LogAGX, Warning, TEXT("Found property named %s of type %s."), *Property->GetName(),
 				*Property->GetCPPType());
+			if (Property->HasAnyPropertyFlags(CPF_Deprecated))
+			{
+				continue;
+			}
 			void* PropertyMemory = Property->ContainerPtrToValuePtr<void>(StructMemory);
 			if (Property->GetCPPType() == CPPType)
 			{
@@ -56,6 +60,10 @@ namespace AGX_TerrainMaterialSpec_helpers
 			UE_LOG(
 				LogAGX, Warning, TEXT("Found property named %s of type %s."), *Property->GetName(),
 				*Property->GetCPPType());
+			if (Property->HasAnyPropertyFlags(CPF_Deprecated))
+			{
+				continue;
+			}
 			void* PropertyMemory = Property->ContainerPtrToValuePtr<void>(Object);
 			if (Property->GetCPPType() == CPPType)
 			{

--- a/Source/AGXUnrealTests/Private/AGX_TerrainMaterial.spec.cpp
+++ b/Source/AGXUnrealTests/Private/AGX_TerrainMaterial.spec.cpp
@@ -185,7 +185,9 @@ void FAGX_TerrainMaterialSpec::Define()
 				   double BankStatePhi0Agx {1.0};
 				   Source->TerrainCompaction.BankStatePhi0 = BankStatePhi0Agx;
 
-				   UWorld* World = UWorld::CreateWorld(
+				   // Create a temporary world to hold our Terrain Material instance, so we don't
+				   // put stuff that shouldn't be there in the main world.
+				   TObjectPtr<UWorld> World = UWorld::CreateWorld(
 					   EWorldType::Game, false, TEXT("Terrain Material Test World"),
 					   GetTransientPackage());
 
@@ -240,6 +242,8 @@ void FAGX_TerrainMaterialSpec::Define()
 					   Source->GetShapeMaterialWireProperties());
 
 				   TestAllRealPropertiesHaveIncreasingValues(Destination, *this);
+
+				   World->DestroyWorld(false);
 			   });
 		});
 }


### PR DESCRIPTION
Fix some Terrain Material properties not being copied in all cases. Add unit test to make sure properties added to Terrain Material in the future aren't missed in the same way. My hope is that the structure of this new test can be turned into a test helper than can be used to create similar tests for all asset types.