### PR TITLE
fix/contact-material-library-friction

### DIFF
--- a/Source/AGXUnreal/Private/Constraints/AGX_ConstraintComponent.cpp
+++ b/Source/AGXUnreal/Private/Constraints/AGX_ConstraintComponent.cpp
@@ -473,6 +473,27 @@ bool UAGX_ConstraintComponent::GetValid() const
 	return NativeBarrier->GetValid();
 }
 
+double UAGX_ConstraintComponent::GetCurrentForce(EGenericDofIndex Dof) const
+{
+	if (!HasNative())
+	{
+		return 0.0;
+	}
+
+	int32 DofAGX;
+	if (!ToNativeDof(Dof, DofAGX))
+	{
+		UE_LOG(
+			LogAGX, Warning,
+			TEXT("Invalid degree of freedom for constraint type %s passed to %s on "
+				 "'%s' in '%s'."),
+			*GetClass()->GetName(), TEXT("Get Current Force"), *GetName(),
+			*GetLabelSafe(GetOwner()));
+		return 0.0;
+	}
+	return NativeBarrier->GetCurrentForce(DofAGX);
+}
+
 bool UAGX_ConstraintComponent::GetLastForceIndex(
 	int32 BodyIndex, FVector& OutForce, FVector& OutTorque, bool bForceAtCm) const
 {

--- a/Source/AGXUnreal/Public/Constraints/AGX_ConstraintComponent.h
+++ b/Source/AGXUnreal/Public/Constraints/AGX_ConstraintComponent.h
@@ -227,7 +227,7 @@ public:
 	bool GetValid() const;
 
 	/**
-	 * Get the current force of the constraint along a particular degree of freedom.
+	 * Get the current force [N] or torque [Nm] of the constraint along a particular degree of freedom.
 	 *
 	 * Only degrees of freedoms listed in the return value of GetLockedDofsBitmask may be passed.
 	 *

--- a/Source/AGXUnreal/Public/Constraints/AGX_ConstraintComponent.h
+++ b/Source/AGXUnreal/Public/Constraints/AGX_ConstraintComponent.h
@@ -227,6 +227,19 @@ public:
 	bool GetValid() const;
 
 	/**
+	 * Get the current force of the constraint along a particular degree of freedom.
+	 *
+	 * Only degrees of freedoms listed in the return value of GetLockedDofsBitmask may be passed.
+	 *
+	 * Consider using one of the Get Last Force functions instead.
+	 *
+	 * @param Dof Degree of freedom to get current force for.
+	 * @return Constraint force in the given degree of freedom.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "AGX Constraint")
+	double GetCurrentForce(EGenericDofIndex Dof) const;
+
+	/**
 	 * If Compute Forces is enabled, returns the last force [N] and torque [Nm] applied by this
 	 * constraint on the body at \p BodyIndex. The force is given in world coordinates and is the
 	 * one applied at the anchor position of this constraint.

--- a/Source/AGXUnrealBarrier/Private/Constraints/ConstraintBarrier.cpp
+++ b/Source/AGXUnrealBarrier/Private/Constraints/ConstraintBarrier.cpp
@@ -174,6 +174,13 @@ FAGX_RealInterval FConstraintBarrier::GetForceRange(int32 Dof) const
 	return FAGX_RealInterval(Range.lower(), Range.upper());
 }
 
+double FConstraintBarrier::GetCurrentForce(int32 Dof)
+{
+	check(HasNative());
+	return NativeRef->Native->getCurrentForce(Dof);
+}
+
+
 void FConstraintBarrier::SetEnableComputeForces(bool bEnable)
 {
 	check(HasNative());

--- a/Source/AGXUnrealBarrier/Public/Constraints/ConstraintBarrier.h
+++ b/Source/AGXUnrealBarrier/Public/Constraints/ConstraintBarrier.h
@@ -74,6 +74,8 @@ public:
 	void GetForceRange(double* Min, double* Max, int32 Dof) const;
 	FAGX_RealInterval GetForceRange(int32 Dof) const;
 
+	double GetCurrentForce(int32 Dof);
+
 	void SetEnableComputeForces(bool bEnable);
 	bool GetEnableComputeForces() const;
 

--- a/Source/AGXUnrealEditor/Private/AGX_RigidBodyComponentCustomization.cpp
+++ b/Source/AGXUnrealEditor/Private/AGX_RigidBodyComponentCustomization.cpp
@@ -3,6 +3,7 @@
 #include "AGX_RigidBodyComponentCustomization.h"
 
 // AGX Dynamics for Unreal includes.
+#include "AGX_RigidBodyCustomizationRuntime.h"
 #include "Utilities/AGX_EditorUtilities.h"
 
 // Unreal Engine includes.
@@ -31,44 +32,9 @@ void FAGX_RigidBodyComponentCustomization::CustomizeDetails(IDetailLayoutBuilder
 
 	RigidBodyComponent->OnComponentView();
 
-	// clang-format off
-
 	IDetailCategoryBuilder& Runtime =
 		DetailBuilder->EditCategory(TEXT("AGX Runtime"), LOCTEXT("AGXRuntime", "AGX Runtime"));
-
-	FDetailWidgetRow& HasNativeRow = Runtime.AddCustomRow(LOCTEXT("HasNative", "HasNative"));
-	HasNativeRow
-	.NameContent()
-	[
-		SNew(STextBlock)
-		.Text(LOCTEXT("HasNative", "Has Native"))
-	]
-	.ValueContent()
-	[
-		SNew(STextBlock)
-		.Text(this, &FAGX_RigidBodyComponentCustomization::GetHasNativeText)
-	];
-
-	// clang-format on
-}
-
-FText FAGX_RigidBodyComponentCustomization::GetHasNativeText() const
-{
-	if (DetailBuilder == nullptr)
-	{
-		return LOCTEXT("NoDetailBuilder", "No DetailBuilder, cannot get object being customized.");
-	}
-
-	UAGX_RigidBodyComponent* Body =
-		FAGX_EditorUtilities::GetSingleObjectBeingCustomized<UAGX_RigidBodyComponent>(
-			*DetailBuilder);
-
-	if (Body == nullptr)
-	{
-		return LOCTEXT("(no body)", "(no body)");
-	}
-
-	return Body->HasNative() ? LOCTEXT("true", "true") : LOCTEXT("false", "false");
+	Runtime.AddCustomBuilder(MakeShareable(new FAGX_RigidBodyCustomizationRuntime(*DetailBuilder)));
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/AGXUnrealEditor/Private/AGX_RigidBodyCustomizationRuntime.cpp
+++ b/Source/AGXUnrealEditor/Private/AGX_RigidBodyCustomizationRuntime.cpp
@@ -1,0 +1,165 @@
+// Copyright 2024, Algoryx Simulation AB.
+
+#include "AGX_RigidBodyCustomizationRuntime.h"
+
+// AGX Dynamics for Unreal includes.
+#include "AGX_RigidBodyComponent.h"
+
+// Unreal Engine includes.
+#include "DetailLayoutBuilder.h"
+#include "DetailWidgetRow.h"
+#include "IDetailChildrenBuilder.h"
+#include "IDetailGroup.h"
+#include "Widgets/Text/STextBlock.h"
+
+#define LOCTEXT_NAMESPACE "AGX_RigidBodyCustomizationRuntime"
+
+FAGX_RigidBodyCustomizationRuntime::FAGX_RigidBodyCustomizationRuntime(
+	IDetailLayoutBuilder& InDetailBuilder)
+	: DetailBuilder(InDetailBuilder)
+{
+	UpdateValues();
+}
+
+void FAGX_RigidBodyCustomizationRuntime::GenerateHeaderRowContent(FDetailWidgetRow& NodeRow)
+{
+	// By having an empty header row Slate won't generate a collapsable section for the node
+	// details.
+	/// @todo Maybe we do want one in this case?
+}
+
+namespace FAGX_RigidBodyCustomizationRuntime_helpers
+{
+	template <class FOnGet>
+	void CreateRuntimeDisplay(IDetailGroup& Group, const FText& Name, FOnGet OnGet)
+	{
+		// clang-format off
+		Group.AddWidgetRow()
+		.NameContent()
+		[
+			SNew(STextBlock)
+			.Font(IDetailLayoutBuilder::GetDetailFont())
+			.Text(Name)
+		]
+		.ValueContent()
+		[
+			SNew(STextBlock)
+			.Font(IDetailLayoutBuilder::GetDetailFont())
+			.Text_Lambda(OnGet)
+		];
+		// clang-format on
+	}
+
+	template <typename FOnGet>
+	void CreateRuntimeDisplay(IDetailChildrenBuilder& Builder, const FText& Name, FOnGet OnGet)
+	{
+		// clang-format off
+		Builder.AddCustomRow(Name)
+		.NameContent()
+		[
+			SNew(STextBlock)
+			.Font(IDetailLayoutBuilder::GetDetailFont())
+			.Text(Name)
+		]
+		.ValueContent()
+		[
+			SNew(STextBlock)
+			.Font(IDetailLayoutBuilder::GetDetailFont())
+			.Text_Lambda(OnGet)
+		];
+		// clang-format on
+	}
+}
+
+void FAGX_RigidBodyCustomizationRuntime::GenerateChildContent(
+	IDetailChildrenBuilder& ChildrenBuilder)
+{
+	using namespace FAGX_RigidBodyCustomizationRuntime_helpers;
+
+	// IDetailGroup& Group = ChildrenBuilder.AddGroup(TEXT("Runtime"), LOCTEXT("Runtime",
+	// "Runtime"));
+	CreateRuntimeDisplay(
+		ChildrenBuilder, LOCTEXT("HasNative", "Has Native"), [this]() { return HasNative; });
+
+// External force is problematic since it is cleared at the end of the step. So how do we read it?
+// Pre Step is too early because gravity hasn't been added yet. Post step is tool late because that
+// is after the Clear Forces kernel.
+#if 0
+	CreateRuntimeDisplay(
+		ChildrenBuilder, LOCTEXT("ExternalForce", "External Force"),
+		[this]() { return ExternalForce; });
+#endif
+}
+
+bool FAGX_RigidBodyCustomizationRuntime::InitiallyCollapsed() const
+{
+	return false;
+}
+
+void FAGX_RigidBodyCustomizationRuntime::SetOnRebuildChildren(
+	FSimpleDelegate InOnRegenerateChildren)
+{
+	OnRegenerateChildren = InOnRegenerateChildren;
+}
+
+FName FAGX_RigidBodyCustomizationRuntime::GetName() const
+{
+	return TEXT("Runtime");
+}
+
+bool FAGX_RigidBodyCustomizationRuntime::RequiresTick() const
+{
+	return true;
+}
+
+void FAGX_RigidBodyCustomizationRuntime::Tick(float DeltaTime)
+{
+	UpdateValues();
+}
+
+void FAGX_RigidBodyCustomizationRuntime::UpdateValues()
+{
+	static const FText NoObject = LOCTEXT("NoObject", "No Object");
+	static const FText MultipleObject = LOCTEXT("MultipleObjects", "Multiple Objects");
+	static const FText NoNative = LOCTEXT("NoNative", "No Native");
+
+	TArray<TWeakObjectPtr<UObject>> Objects;
+	DetailBuilder.GetObjectsBeingCustomized(Objects);
+	if (Objects.Num() < 1)
+	{
+		SetAll(NoObject);
+		return;
+	}
+	if (Objects.Num() > 1)
+	{
+		SetAll(MultipleObject);
+		return;
+	}
+
+	TWeakObjectPtr<UObject> Object = Objects[0];
+	if (!Object.IsValid())
+	{
+		SetAll(NoObject);
+		return;
+	}
+
+	UAGX_RigidBodyComponent* Body = Cast<UAGX_RigidBodyComponent>(Object.Get());
+	if (Body == nullptr)
+	{
+		// Not really true. There is an object, it just isn't a Rigid Body.
+		SetAll(NoObject);
+		return;
+	}
+
+	if (!Body->HasNative())
+	{
+		SetAll(NoNative);
+		return;
+	}
+
+	HasNative = Body->HasNative() ? LOCTEXT("True", "True") : LOCTEXT("False", "False");
+	ExternalForce = FText::Format(
+		LOCTEXT("ExternalForceValue", "{0} N"), FText::FromString(Body->GetForce().ToString()));
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/AGXUnrealEditor/Private/Constraints/AGX_ConstraintCustomization.cpp
+++ b/Source/AGXUnrealEditor/Private/Constraints/AGX_ConstraintCustomization.cpp
@@ -4,6 +4,7 @@
 
 // AGX Dynamics for Unreal includes.
 #include "Constraints/AGX_ConstraintComponent.h"
+#include "Constraints/AGX_ConstraintCustomizationRuntime.h"
 #include "Utilities/AGX_EditorUtilities.h"
 
 // Unreal Engine includes.
@@ -45,6 +46,11 @@ void FAGX_ConstraintCustomization::CustomizeDetails(IDetailLayoutBuilder& InDeta
 	.Visibility(TAttribute<EVisibility>(
 		this, &FAGX_ConstraintCustomization::VisibleWhenBodySetupError));
 	// clang-format on
+
+	IDetailCategoryBuilder& Runtime =
+		DetailBuilder->EditCategory(TEXT("AGX Runtime"), LOCTEXT("AGXRuntime", "AGX Runtime"));
+	Runtime.AddCustomBuilder(
+		MakeShareable(new FAGX_ConstraintCustomizationRuntime(*DetailBuilder)));
 }
 
 namespace AGX_ConstraintCustomization_helpers
@@ -56,7 +62,8 @@ namespace AGX_ConstraintCustomization_helpers
 		SameBody = 1 << 1
 	};
 
-	EAGX_AttachmentSetupError& operator|=(EAGX_AttachmentSetupError& InOutLhs, EAGX_AttachmentSetupError InRhs)
+	EAGX_AttachmentSetupError& operator|=(
+		EAGX_AttachmentSetupError& InOutLhs, EAGX_AttachmentSetupError InRhs)
 	{
 		int Lhs = (int) InOutLhs;
 		int Rhs = (int) InRhs;
@@ -65,7 +72,8 @@ namespace AGX_ConstraintCustomization_helpers
 		return InOutLhs;
 	}
 
-	EAGX_AttachmentSetupError operator&(EAGX_AttachmentSetupError InLhs, EAGX_AttachmentSetupError InRhs)
+	EAGX_AttachmentSetupError operator&(
+		EAGX_AttachmentSetupError InLhs, EAGX_AttachmentSetupError InRhs)
 	{
 		int Lhs = (int) InLhs;
 		int Rhs = (int) InRhs;

--- a/Source/AGXUnrealEditor/Private/Constraints/AGX_ConstraintCustomizationRuntime.cpp
+++ b/Source/AGXUnrealEditor/Private/Constraints/AGX_ConstraintCustomizationRuntime.cpp
@@ -1,0 +1,181 @@
+// Copyright 2024, Algoryx Simulation AB.
+
+#include "Constraints/AGX_ConstraintCustomizationRuntime.h"
+
+// AGX Dynamics for Unreal includes.
+#include "Constraints/AGX_ConstraintComponent.h"
+#include "Constraints/AGX_Constraint1DofComponent.h"
+#include "Constraints/AGX_Constraint2DofComponent.h"
+
+// Unreal Engine includes.
+#include "DetailLayoutBuilder.h"
+#include "DetailWidgetRow.h"
+#include "IDetailChildrenBuilder.h"
+#include "IDetailGroup.h"
+#include "Widgets/Text/STextBlock.h"
+
+#define LOCTEXT_NAMESPACE "AGX_ConstraintCustomizationRuntime"
+
+FAGX_ConstraintCustomizationRuntime::FAGX_ConstraintCustomizationRuntime(
+	IDetailLayoutBuilder& InDetailBuilder)
+	: DetailBuilder(InDetailBuilder)
+{
+	UpdateValues();
+}
+
+void FAGX_ConstraintCustomizationRuntime::GenerateHeaderRowContent(FDetailWidgetRow& NodeRow)
+{
+	// By having an empty header row Slate won't generate a collapsable section for the node
+	// details.
+	/// @todo Maybe we do want one in this case?
+}
+
+namespace FAGX_ConstraintCustomizationRuntime_helpers
+{
+	template <class FOnGet>
+	void CreateRuntimeDisplay(IDetailGroup& Group, const FText& Name, FOnGet OnGet)
+	{
+		// clang-format off
+		Group.AddWidgetRow()
+		.NameContent()
+		[
+			SNew(STextBlock)
+			.Font(IDetailLayoutBuilder::GetDetailFont())
+			.Text(Name)
+		]
+		.ValueContent()
+		[
+			SNew(STextBlock)
+			.Font(IDetailLayoutBuilder::GetDetailFont())
+			.Text_Lambda(OnGet)
+		];
+		// clang-format on
+	}
+
+	template <typename FOnGet>
+	void CreateRuntimeDisplay(IDetailChildrenBuilder& Builder, const FText& Name, FOnGet OnGet)
+	{
+		// clang-format off
+		Builder.AddCustomRow(Name)
+		.NameContent()
+		[
+			SNew(STextBlock)
+			.Font(IDetailLayoutBuilder::GetDetailFont())
+			.Text(Name)
+		]
+		.ValueContent()
+		[
+			SNew(STextBlock)
+			.Font(IDetailLayoutBuilder::GetDetailFont())
+			.Text_Lambda(OnGet)
+		];
+		// clang-format on
+	}
+}
+
+void FAGX_ConstraintCustomizationRuntime::GenerateChildContent(
+	IDetailChildrenBuilder& ChildrenBuilder)
+{
+	using namespace FAGX_ConstraintCustomizationRuntime_helpers;
+
+	CreateRuntimeDisplay(
+		ChildrenBuilder, LOCTEXT("HasNative", "Has Native"), [this]() { return HasNative; });
+	CreateRuntimeDisplay(
+		ChildrenBuilder, LOCTEXT("CurrentForce", "Current Force"),
+		[this]() { return CurrentForce; });
+
+	IDetailGroup& FirstDofGroup = ChildrenBuilder.AddGroup(
+		TEXT("FirstDegreeOfFreedom"),
+		LOCTEXT("First Degree Of Freedom", "First Degree Of Freedom"));
+	CreateRuntimeDisplay(
+		FirstDofGroup, LOCTEXT("MotorController", "Motor Controller"),
+		[this]() { return FirstDof.MotorControllerForce; });
+	CreateRuntimeDisplay(
+		FirstDofGroup, LOCTEXT("LockController", "Lock Controller"),
+		[this]() { return FirstDof.LockControllerForce; });
+}
+
+bool FAGX_ConstraintCustomizationRuntime::InitiallyCollapsed() const
+{
+	return false;
+}
+
+void FAGX_ConstraintCustomizationRuntime::SetOnRebuildChildren(
+	FSimpleDelegate InOnRegenerateChildren)
+{
+	OnRegenerateChildren = InOnRegenerateChildren;
+}
+
+FName FAGX_ConstraintCustomizationRuntime::GetName() const
+{
+	return TEXT("Runtime");
+}
+
+bool FAGX_ConstraintCustomizationRuntime::RequiresTick() const
+{
+	return true;
+}
+
+void FAGX_ConstraintCustomizationRuntime::Tick(float DeltaTime)
+{
+	UpdateValues();
+}
+
+void FAGX_ConstraintCustomizationRuntime::UpdateValues()
+{
+	static const FText NoObject = LOCTEXT("NoObject", "No Object");
+	static const FText MultipleObject = LOCTEXT("MultipleObjects", "Multiple Objects");
+	static const FText NoNative = LOCTEXT("NoNative", "No Native");
+
+	TArray<TWeakObjectPtr<UObject>> Objects;
+	DetailBuilder.GetObjectsBeingCustomized(Objects);
+	if (Objects.Num() < 1)
+	{
+		HasNative = NoObject;
+		return;
+	}
+	if (Objects.Num() > 1)
+	{
+		HasNative = MultipleObject;
+		return;
+	}
+
+	TWeakObjectPtr<UObject> Object = Objects[0];
+	if (!Object.IsValid())
+	{
+		HasNative = NoObject;
+		return;
+	}
+
+	UAGX_ConstraintComponent* Constraint = Cast<UAGX_ConstraintComponent>(Object.Get());
+	if (Constraint == nullptr)
+	{
+		// Not really true. There is an object, it just isn't a Rigid Body.
+		HasNative = NoObject;
+		return;
+	}
+
+	if (!Constraint->HasNative())
+	{
+		HasNative = NoNative;
+		return;
+	}
+
+	HasNative = Constraint->HasNative() ? LOCTEXT("True", "True") : LOCTEXT("False", "False");
+	CurrentForce = FText::Format(
+		LOCTEXT("ExternalForceValue", "{0} N"),
+		FText::AsNumber(Constraint->GetCurrentForce(EGenericDofIndex::Translational1)));
+
+	if (UAGX_Constraint1DofComponent* OneDof = Cast<UAGX_Constraint1DofComponent>(Constraint))
+	{
+		FirstDof.MotorControllerForce = FText::AsNumber(OneDof->TargetSpeedController.GetForce());
+		FirstDof.LockControllerForce = FText::AsNumber(OneDof->LockController.GetForce());
+	}
+	if (UAGX_Constraint2DofComponent* TwoDof = Cast<UAGX_Constraint2DofComponent>(Constraint))
+	{
+		FirstDof.MotorControllerForce = FText::AsNumber(TwoDof->TargetSpeedController1.GetForce());
+		SecondDof.MotorControllerForce = FText::AsNumber(TwoDof->TargetSpeedController2.GetForce());
+	}
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/AGXUnrealEditor/Public/AGX_RigidBodyComponentCustomization.h
+++ b/Source/AGXUnrealEditor/Public/AGX_RigidBodyComponentCustomization.h
@@ -20,11 +20,12 @@ class AGXUNREALEDITOR_API FAGX_RigidBodyComponentCustomization : public IDetailC
 public:
 	static TSharedRef<IDetailCustomization> MakeInstance();
 
+	//~ Begin IDetailCustomNodeBuilder.
 	virtual void CustomizeDetails(IDetailLayoutBuilder& InDetailBuilder) override;
-
-private:
-	FText GetHasNativeText() const;
+	//~ End IDetailCustomNodeBuilder.
 
 private:
 	IDetailLayoutBuilder* DetailBuilder;
+
+	FText ExternalForce;
 };

--- a/Source/AGXUnrealEditor/Public/AGX_RigidBodyCustomizationRuntime.h
+++ b/Source/AGXUnrealEditor/Public/AGX_RigidBodyCustomizationRuntime.h
@@ -1,0 +1,45 @@
+// Copyright 2024, Algoryx Simulation AB.
+
+#pragma once
+
+// Unreal Engine includes.
+#include "IDetailCustomNodeBuilder.h"
+
+class IDetailLayoutBuilder;
+
+/**
+ * A group in the Details panel for Rigid Body that displays data that isn't an Unreal Engine
+ * property, things that are internal to the simulation but still interesting for the user.
+ */
+class FAGX_RigidBodyCustomizationRuntime : public IDetailCustomNodeBuilder
+{
+public:
+	FAGX_RigidBodyCustomizationRuntime(IDetailLayoutBuilder& InDetailBuilder);
+
+	//~ Begin IDetailCustomNodeBuilder.
+	virtual void GenerateHeaderRowContent(FDetailWidgetRow& NodeRow) override;
+	virtual void GenerateChildContent(IDetailChildrenBuilder& ChildrenBuilder) override;
+	virtual bool InitiallyCollapsed() const override;
+	virtual void SetOnRebuildChildren(FSimpleDelegate InOnRegenerateChildren) override;
+	virtual FName GetName() const override;
+	virtual bool RequiresTick() const override;
+	virtual void Tick(float DeltaTime) override;
+	//~ End IDetailCustomNodeBuilder.
+
+public:
+	void UpdateValues();
+
+public:
+	FText HasNative;
+	FText ExternalForce;
+
+	void SetAll(const FText& Text)
+	{
+		HasNative = Text;
+		ExternalForce = Text;
+	}
+
+public:
+	IDetailLayoutBuilder& DetailBuilder;
+	FSimpleDelegate OnRegenerateChildren;
+};

--- a/Source/AGXUnrealEditor/Public/Constraints/AGX_ConstraintCustomizationRuntime.h
+++ b/Source/AGXUnrealEditor/Public/Constraints/AGX_ConstraintCustomizationRuntime.h
@@ -1,0 +1,52 @@
+// Copyright 2024, Algoryx Simulation AB.
+
+#pragma once
+
+// Unreal Engine includes.
+#include "IDetailCustomNodeBuilder.h"
+
+class IDetailLayoutBuilder;
+
+/**
+ * A group in the Details panel for Constraint that displays data that isn't an Unreal Engine
+ * property, things that are internal to the simulation but still interesting for the user.
+ */
+class FAGX_ConstraintCustomizationRuntime : public IDetailCustomNodeBuilder
+{
+public:
+	FAGX_ConstraintCustomizationRuntime(IDetailLayoutBuilder& InDetailBuilder);
+
+	//~ Begin IDetailCustomNodeBuilder.
+	virtual void GenerateHeaderRowContent(FDetailWidgetRow& NodeRow) override;
+	virtual void GenerateChildContent(IDetailChildrenBuilder& ChildrenBuilder) override;
+	virtual bool InitiallyCollapsed() const override;
+	virtual void SetOnRebuildChildren(FSimpleDelegate InOnRegenerateChildren) override;
+	virtual FName GetName() const override;
+	virtual bool RequiresTick() const override;
+	virtual void Tick(float DeltaTime) override;
+	//~ End IDetailCustomNodeBuilder.
+
+public:
+	void UpdateValues();
+
+public:
+	FText HasNative;
+
+	FText CurrentForce;
+
+	struct FFirstDof
+	{
+		FText MotorControllerForce;
+		FText LockControllerForce;
+	} FirstDof;
+
+	struct FSecondDof
+	{
+		FText MotorControllerForce;
+		FText LockControllerForce;
+	} SecondDof;
+
+public:
+	IDetailLayoutBuilder& DetailBuilder;
+	FSimpleDelegate OnRegenerateChildren;
+};


### PR DESCRIPTION
Set default friction model and contact solve type for Contact Materials imported from AGX Dynamics' material library.

Also extensions to the runtime Details panel categories for Rigid Body and Constraint. Still work-in-progress, but another step forward.