### PR TITLE
fix/raytrace-supported-check-fix

### DIFF
--- a/Source/AGXUnrealBarrier/Private/Sensors/SensorEnvironmentBarrier.cpp
+++ b/Source/AGXUnrealBarrier/Private/Sensors/SensorEnvironmentBarrier.cpp
@@ -191,7 +191,7 @@ bool FSensorEnvironmentBarrier::IsRaytraceSupported()
 
 	std::call_once(
 		InitFlag,
-		[]()
+		[&]()
 		{
 			bIsRaytraceSupported = agxSensor::RtConfig::isRaytraceSupported();
 			if (!bIsRaytraceSupported)
@@ -210,7 +210,6 @@ bool FSensorEnvironmentBarrier::IsRaytraceSupported()
 			catch (...)
 			{
 				UE_LOG(LogAGX, Log, TEXT("Caught exception after Lidar material initialization."));
-				Barrier.ReleaseNative();
 				bIsRaytraceSupported = false;
 			}
 		});


### PR DESCRIPTION
Safely sanity check test the raytrace support test. 
We have encountered a situation where the raytrace library threw an exception due to old drivers during init, so here we force the library to initialize once but within a try/catch. 


