### PR TITLE
fix/constraint-same-body-error-none-blueprint

### DIFF
--- a/Source/AGXUnrealEditor/Private/AGX_ComponentReferenceCustomization.cpp
+++ b/Source/AGXUnrealEditor/Private/AGX_ComponentReferenceCustomization.cpp
@@ -476,7 +476,7 @@ void FAGX_ComponentReferenceCustomization::OnComboBoxChanged(
 	if (ComponentReferenceHandle.IsValid() && ComponentReferenceHandle->IsValidHandle() &&
 		ComponentReferenceHandle->GetNumPerObjectValues() == 0)
 	{
-		// I looks like Blueprint Reconstruction happened, which means that both the object we
+		// It looks like Blueprint Reconstruction happened, which means that both the object we
 		// were editing and the entire Details panel has been destroyed. We can do nothing more.
 		return;
 	}

--- a/Source/AGXUnrealEditor/Private/Constraints/AGX_ConstraintCustomization.cpp
+++ b/Source/AGXUnrealEditor/Private/Constraints/AGX_ConstraintCustomization.cpp
@@ -98,16 +98,19 @@ namespace AGX_ConstraintCustomization_helpers
 			if (Constraint == nullptr)
 				continue;
 
-			const FName RB1Name = Constraint->BodyAttachment1.RigidBody.Name;
-			const AActor* RB1LocalScope = Constraint->BodyAttachment1.RigidBody.LocalScope;
-			const FName RB2Name = Constraint->BodyAttachment2.RigidBody.Name;
-			const AActor* RB2LocalScope = Constraint->BodyAttachment2.RigidBody.LocalScope;
+			const FAGX_RigidBodyReference& Attachment1 = Constraint->BodyAttachment1.RigidBody;
+			const FName Name1 = Attachment1.Name;
+			const AActor* Scope1 = Attachment1.GetScope();
 
-			if (RB1Name.IsNone())
+			const FAGX_RigidBodyReference& Attachment2 = Constraint->BodyAttachment2.RigidBody;
+			const FName Name2 = Attachment2.Name;
+			const AActor* Scope2 = Attachment2.GetScope();
+
+			if (Name1.IsNone())
 			{
 				Error |= EAGX_AttachmentSetupError::NoFirstBody;
 			}
-			else if (RB1Name == RB2Name && RB1LocalScope == RB2LocalScope)
+			else if (Name1 == Name2 && Scope1 == Scope2)
 			{
 				Error |= EAGX_AttachmentSetupError::SameBody;
 			}


### PR DESCRIPTION
Allow a constraint to attach to two bodies with the same name if they are in different Actors.