### PR TITLE
feature/native-owner-unreal-interface

### DIFF
--- a/Source/AGXUnreal/Public/AGX_NativeOwner.h
+++ b/Source/AGXUnreal/Public/AGX_NativeOwner.h
@@ -9,7 +9,15 @@
 #include <cstdint>
 #include <limits>
 
+#include "AGX_NativeOwner.generated.h"
+
 class UActorComponent;
+
+UINTERFACE(MinimalAPI, Blueprintable)
+class UAGX_NativeOwner : public UInterface
+{
+	GENERATED_BODY()
+};
 
 /**
  * Interface implemented by all classes that owns an AGX Dynamics native object.
@@ -65,6 +73,7 @@ class UActorComponent;
  */
 class IAGX_NativeOwner
 {
+	GENERATED_BODY()
 public:
 	/** @return True if this Native Owner currently owns a native AGX Dynamics object. */
 	virtual bool HasNative() const = 0;
@@ -84,8 +93,6 @@ public:
 	 * should own.
 	 */
 	virtual void SetNativeAddress(uint64 NativeAddress) = 0;
-
-	virtual ~IAGX_NativeOwner() = default;
 };
 
 // Make sure we can hold an address in an uint64.


### PR DESCRIPTION
Make IAGX_NativeOwner an Unreal Interface by adding UAGX_NativeOwner inheriting from UInterface. This makes it possible to use with `Cast<>`.

Destructor removed because it is included in GENERATED_BODY.