### PR TITLE
fix/files-to-ignore-removed

### DIFF
--- a/Source/ThirdParty/AGXDynamicsLibrary/AGXDynamicsLibrary.Build.cs
+++ b/Source/ThirdParty/AGXDynamicsLibrary/AGXDynamicsLibrary.Build.cs
@@ -679,7 +679,7 @@ public class AGXDynamicsLibrary : ModuleRules
 		{
 			string Source = InstalledAGXResources.IncludePath(IncludePath);
 			string Dest = BundledAGXResources.IncludePath(IncludePath);
-			if (!CopyDirectoryRecursively(Source, Dest, FilesToIgnore))
+			if (!CopyDirectoryRecursively(Source, Dest))
 			{
 				CleanBundledAGXDynamicsResources();
 				return;


### PR DESCRIPTION
In AGXDynamnicsLibrary.Biuld.cs, don't try to pass a variable that doesn't exist to CopyDirectoryRecursively