### PR TITLE
fix/openplx-secondary-constraint-name

### DIFF
--- a/Source/AGXUnreal/Private/Constraints/AGX_SingleControllerConstraint1DofComponent.cpp
+++ b/Source/AGXUnreal/Private/Constraints/AGX_SingleControllerConstraint1DofComponent.cpp
@@ -125,8 +125,15 @@ void UAGX_SingleControllerConstraint1DofComponent::CreateNativeImpl()
 	FTransform Transform2 =
 		FAGX_ConstraintUtilities::GetFrameTransform(BodyAttachment2, GetFName(), OwnerName);
 
+	// agxOpenPLX require that both a Single Controller Constraint and its Secondary Constraint,
+	// e.g. a Target Speed Controller, have the same name as in the OpenPLX model. This is required
+	// for input signal routing to work. So this name must match the name set on the Native in
+	// UAGX_ConstraintComponent::UpdateNativeProperties.
+	const FString ConstraintName = !ImportName.IsEmpty() ? ImportName : GetName();
+
 	auto BarrierSCC1DOF = static_cast<FSingleControllerConstraint1DOFBarrier*>(NativeBarrier.Get());
 	BarrierSCC1DOF->AllocateNative(
 		*Body1, Transform1.GetLocation(), Transform1.GetRotation(), Body2, Transform2.GetLocation(),
-		Transform2.GetRotation(), Controller->GetNative(), ControllerType, ControllerAngleType);
+		Transform2.GetRotation(), Controller->GetNative(), ControllerType, ControllerAngleType,
+		ConstraintName);
 }

--- a/Source/AGXUnrealBarrier/Private/Constraints/SingleControllerConstraint1DOFBarrier.cpp
+++ b/Source/AGXUnrealBarrier/Private/Constraints/SingleControllerConstraint1DOFBarrier.cpp
@@ -8,6 +8,7 @@
 #include "BarrierOnly/AGXRefs.h"
 #include "Constraints/ControllerConstraintBarriers.h"
 #include "RigidBodyBarrier.h"
+#include "TypeConversions.h"
 #include "Utilities/AGX_BarrierConstraintUtilities.h"
 
 #include "BeginAGXIncludes.h"
@@ -34,7 +35,7 @@ void FSingleControllerConstraint1DOFBarrier::AllocateNative(
 	const FRigidBodyBarrier& Rb1, const FVector& FramePosition1, const FQuat& FrameRotation1,
 	const FRigidBodyBarrier* Rb2, const FVector& FramePosition2, const FQuat& FrameRotation2,
 	FConstraintControllerBarrier* Controller, EAGX_ConstraintControllerType ControllerType,
-	EAGX_ConstraintAngleControllerType ControllerAngleType)
+	EAGX_ConstraintAngleControllerType ControllerAngleType, const FString& Name)
 {
 	check(!HasNative());
 	check(Controller != nullptr);
@@ -77,6 +78,8 @@ void FSingleControllerConstraint1DOFBarrier::AllocateNative(
 			*GetName());
 		return;
 	}
+
+	Controller->GetNative()->Native->setName(Convert(Name));
 
 	agx::RigidBody* NativeRigidBody1 = nullptr;
 	agx::RigidBody* NativeRigidBody2 = nullptr;

--- a/Source/AGXUnrealBarrier/Public/Constraints/SingleControllerConstraint1DOFBarrier.h
+++ b/Source/AGXUnrealBarrier/Public/Constraints/SingleControllerConstraint1DOFBarrier.h
@@ -24,7 +24,8 @@ public:
 		const FRigidBodyBarrier* Rb2, const FVector& FramePosition2, const FQuat& FrameRotation2,
 		FConstraintControllerBarrier* Controller,
 		EAGX_ConstraintControllerType ControllerType,
-		EAGX_ConstraintAngleControllerType ControllerAngleType);
+		EAGX_ConstraintAngleControllerType ControllerAngleType,
+		const FString& Name);
 
 	EAGX_ConstraintControllerType GetControllerType() const;
 	EAGX_ConstraintAngleControllerType GetControllerAngleType() const;


### PR DESCRIPTION
Set name on the Secondary Constraint created for a Single Controller Constraint

This is required for the Signal Source Mapper to be able to route input signals to the Secondary Constraint.