### PR TITLE
fix/agpu-include

### DIFF
--- a/Source/AGXUnrealBarrier/Private/Sensors/SensorEnvironmentBarrier.cpp
+++ b/Source/AGXUnrealBarrier/Private/Sensors/SensorEnvironmentBarrier.cpp
@@ -20,7 +20,7 @@
 
 // AGX Dynamics includes.
 #include "BeginAGXIncludes.h"
-#include <agpu/api/core.h>
+#include <agpu/api/api.h>
 #include <agxSensor/RaytraceAmbientMaterial.h>
 #include <agxSensor/RaytraceSurfaceMaterial.h>
 #include <agxSensor/RaytraceConfig.h>


### PR DESCRIPTION
In SensorEnvironmentBarrier.cpp, include api.h instead of core.h from agpu

It's the same file that has been renamed.