### PR TITLE
fix/niagara-runtime-linkererror

### DIFF
--- a/Config/DefaultAGXUnreal.ini
+++ b/Config/DefaultAGXUnreal.ini
@@ -1,0 +1,2 @@
+[CoreRedirects]
++ClassRedirects=(OldName="/Script/AGXUnrealShaders.AGX_ParticleUpsamplingDI",NewName="/Script/AGXUnreal.AGX_ParticleUpsamplingDI")

--- a/Source/AGXUnreal/Private/AGXUnreal.cpp
+++ b/Source/AGXUnreal/Private/AGXUnreal.cpp
@@ -160,6 +160,12 @@ void FAGXUnrealModule::RegisterCoreRedirects()
 		Redirects.Emplace(ECoreRedirectFlags::Type_Function, *BpName, *Function->GetName());
 	}
 
+	// Niagara types moved from AGXUnrealShaders into AGXUnreal because AGXUnrealShaders is not
+	// reliably loaded after Niagara.
+	Redirects.Emplace(
+		ECoreRedirectFlags::Type_Class, TEXT("/Script/AGXUnrealShaders.AGX_ParticleUpsamplingDI"),
+		TEXT("/Script/AGXUnreal.AGX_ParticleUpsamplingDI"));
+
 	FCoreRedirects::AddRedirectList(Redirects, TEXT("AGXUnreal"));
 }
 

--- a/Source/AGXUnreal/Private/Terrain/ParticleRendering/AGX_ParticleUpsamplingDI.cpp
+++ b/Source/AGXUnreal/Private/Terrain/ParticleRendering/AGX_ParticleUpsamplingDI.cpp
@@ -1,9 +1,9 @@
 // Copyright 2026, Algoryx Simulation AB.
 
-#include "AGX_ParticleUpsamplingDI.h"
+#include "Terrain/ParticleRendering/AGX_ParticleUpsamplingDI.h"
 
 // AGX Dynamics for Unreal includes.
-#include "ParticleUpsamplingDIProxy.h"
+#include "Terrain/ParticleRendering/ParticleUpsamplingDIProxy.h"
 
 // Unreal Engine includes.
 #include "NiagaraCompileHashVisitor.h"
@@ -25,7 +25,7 @@ void UAGX_ParticleUpsamplingDI::PostInitProperties()
 
 	if (HasAnyFlags(RF_ClassDefaultObject))
 	{
-		ENiagaraTypeRegistryFlags Flags = 
+		ENiagaraTypeRegistryFlags Flags =
 			ENiagaraTypeRegistryFlags::AllowAnyVariable | ENiagaraTypeRegistryFlags::AllowParameter;
 		FNiagaraTypeRegistry::Register(FNiagaraTypeDefinition(GetClass()), Flags);
 	}
@@ -165,10 +165,10 @@ void UAGX_ParticleUpsamplingDI::GetParameterDefinitionHLSL(
 {
 	/**
 	 * Since the same data interface can be instantiated multiple times, Niagara needs to know
-	 * which functions referes to which instance when it generates the code from the template file. 
+	 * which functions referes to which instance when it generates the code from the template file.
 	 *
 	 * This replaces the text {ParameterName} with the unique HLSL symbol name of each instance of
-	 * the data interface. This ensures that the generated functions and variables are correctly 
+	 * the data interface. This ensures that the generated functions and variables are correctly
 	 * scoped and does not clash with each other.
 	 */
 	const TMap<FString, FStringFormatArg> TemplateArgs = {

--- a/Source/AGXUnreal/Private/Terrain/ParticleRendering/AGX_UpsamplingParticleRendererComponent.cpp
+++ b/Source/AGXUnreal/Private/Terrain/ParticleRendering/AGX_UpsamplingParticleRendererComponent.cpp
@@ -4,12 +4,12 @@
 
 // AGX Dynamics for Unreal includes.
 #include "AGX_LogCategory.h"
-#include "AGX_ParticleUpsamplingDI.h"
 #include "AGX_PropertyChangedDispatcher.h"
-#include "ParticleUpsamplingDataHandler.h"
 #include "Terrain/AGX_MovableTerrainComponent.h"
 #include "Terrain/AGX_Terrain.h"
 #include "Terrain/ParticleRendering/AGX_ParticleRenderingUtilities.h"
+#include "Terrain/ParticleRendering/AGX_ParticleUpsamplingDI.h"
+#include "Terrain/ParticleRendering/ParticleUpsamplingDataHandler.h"
 #include "Utilities/AGX_NotificationUtilities.h"
 #include "Utilities/AGX_StringUtilities.h"
 
@@ -18,8 +18,8 @@
 #include "NiagaraComponent.h"
 #include "NiagaraDataInterfaceArrayFunctionLibrary.h"
 #include "NiagaraFunctionLibrary.h"
-#include "NiagaraSystemInstanceController.h"
 #include "NiagaraRenderGraphUtils.h"
+#include "NiagaraSystemInstanceController.h"
 #include "SphereTypes.h"
 
 UAGX_UpsamplingParticleRendererComponent::UAGX_UpsamplingParticleRendererComponent()

--- a/Source/AGXUnreal/Private/Terrain/ParticleRendering/ParticleUpsamplingDIProxy.cpp
+++ b/Source/AGXUnreal/Private/Terrain/ParticleRendering/ParticleUpsamplingDIProxy.cpp
@@ -1,9 +1,9 @@
 // Copyright 2026, Algoryx Simulation AB.
 
-#include "ParticleUpsamplingDIProxy.h"
+#include "Terrain/ParticleRendering/ParticleUpsamplingDIProxy.h"
 
 
-/** 
+/**
  * Get the size of the data that will be passed to render.
  */
 int32 FParticleUpsamplingDIProxy::PerInstanceDataPassedToRenderThreadSize() const
@@ -54,4 +54,3 @@ void FParticleUpsamplingDIProxy::ConsumePerInstanceDataFromGameThread(
 	// memory.
 	InstanceDataFromGT->~FParticleUpsamplingDataHandler();
 }
-

--- a/Source/AGXUnreal/Private/Terrain/ParticleRendering/ParticleUpsamplingDataHandler.cpp
+++ b/Source/AGXUnreal/Private/Terrain/ParticleRendering/ParticleUpsamplingDataHandler.cpp
@@ -1,6 +1,6 @@
 // Copyright 2026, Algoryx Simulation AB.
 
-#include "ParticleUpsamplingDataHandler.h"
+#include "Terrain/ParticleRendering/ParticleUpsamplingDataHandler.h"
 
 // Unreal Engine includes.
 #include "Misc/EngineVersionComparison.h"

--- a/Source/AGXUnreal/Public/Terrain/ParticleRendering/AGX_ParticleUpsamplingDI.h
+++ b/Source/AGXUnreal/Public/Terrain/ParticleRendering/AGX_ParticleUpsamplingDI.h
@@ -13,7 +13,7 @@
 #include "AGX_ParticleUpsamplingDI.generated.h"
 
 UCLASS(EditInlineNew, Category = "Data Interface", CollapseCategories, meta = (DisplayName = "Particle Upsampling Data Interface"))
-class AGXUNREALSHADERS_API UAGX_ParticleUpsamplingDI : public UNiagaraDataInterface
+class AGXUNREAL_API UAGX_ParticleUpsamplingDI : public UNiagaraDataInterface
 {
 	GENERATED_UCLASS_BODY()
 
@@ -65,7 +65,7 @@ public:
 		void* PerInstanceData, FNiagaraSystemInstance* SystemInstance) override;
 
 	/**
-	 * This function removes the data of an instance of this NDI and the proxy, meaning that 
+	 * This function removes the data of an instance of this NDI and the proxy, meaning that
 	 * this function will run when hitting the stop button for each instance of this NDI that
 	 * are present.
 	 */
@@ -78,7 +78,7 @@ public:
 	};
 	virtual bool HasPreSimulateTick() const override { return true; };
 
-	/** 
+	/**
 	 * This ticks on the game thread and lets us do work to initialize the instance data.
 	 * If work is needed to be performed on the gathered instance data after the simulation
 	 * is done, use PerInstanceTickPostSimulate() instead.

--- a/Source/AGXUnreal/Public/Terrain/ParticleRendering/ParticleUpsamplingDIProxy.h
+++ b/Source/AGXUnreal/Public/Terrain/ParticleRendering/ParticleUpsamplingDIProxy.h
@@ -9,7 +9,7 @@
 #include "NiagaraDataInterface.h"
 
 /** This proxy is used to safely copy data between game thread and render thread*/
-struct AGXUNREALSHADERS_API FParticleUpsamplingDIProxy : FNiagaraDataInterfaceProxy
+struct AGXUNREAL_API FParticleUpsamplingDIProxy : FNiagaraDataInterfaceProxy
 {
 	// ~Begin FNiagaraDataInterfaceProxy interface.
 

--- a/Source/AGXUnreal/Public/Terrain/ParticleRendering/ParticleUpsamplingDataHandler.h
+++ b/Source/AGXUnreal/Public/Terrain/ParticleRendering/ParticleUpsamplingDataHandler.h
@@ -11,8 +11,8 @@
 
 /**
  * Struct to store data from a single coarse particle.
- */ 
-struct AGXUNREALSHADERS_API FCoarseParticle
+ */
+struct AGXUNREAL_API FCoarseParticle
 {
 	/**
 	 * The position stored at XYZ, the particle radius stored at W.
@@ -28,7 +28,7 @@ struct AGXUNREALSHADERS_API FCoarseParticle
 /**
  * Struct to store data contained in a voxel of the voxel grid.
  */
-struct AGXUNREALSHADERS_API FVoxelEntry
+struct AGXUNREAL_API FVoxelEntry
 {
 	/**
 	 * IndexAndRoom_Index holds the voxel index (XYZ), IndexAndRoom_Room represents
@@ -52,7 +52,7 @@ struct AGXUNREALSHADERS_API FVoxelEntry
 	FVector4f MaxBounds;
 
 	/**
-	 * The min coordinates of the bounding box surrounding coarse particles 
+	 * The min coordinates of the bounding box surrounding coarse particles
 	 * in this voxel stored at XYZ, W is empty.
 	 */
 	FVector4f MinBounds;
@@ -65,14 +65,14 @@ struct AGXUNREALSHADERS_API FVoxelEntry
  *
  * UAVs allow for unordered read/write access from multiple threads by supporting
  * atomic operations. This makes it possible to implement data structures like
- * hash tables directly on the GPU, where multiple threads can perform concurrent 
+ * hash tables directly on the GPU, where multiple threads can perform concurrent
  * inserts and lookups.
  *
  * SRVs provide read-only access to buffers from multiple threads. Although threads
  * can read from the buffer in parallel without conflicts, writing is not allowed,
  * as it would result in exceptions being thrown.
  */
-struct AGXUNREALSHADERS_API FParticleUpsamplingBuffers : public FRenderResource
+struct AGXUNREAL_API FParticleUpsamplingBuffers : public FRenderResource
 {
 	FParticleUpsamplingBuffers()
 		: CoarseParticlesCapacity(0)
@@ -81,54 +81,54 @@ struct AGXUNREALSHADERS_API FParticleUpsamplingBuffers : public FRenderResource
 	}
 
 	FParticleUpsamplingBuffers(uint32 InitialCoarseParticleCapacity, uint32 InitialActiveVoxelsCapacity)
-		: CoarseParticlesCapacity(InitialCoarseParticleCapacity) 
+		: CoarseParticlesCapacity(InitialCoarseParticleCapacity)
 		, ActiveVoxelsCapacity(InitialActiveVoxelsCapacity)
 	{
 	}
-	
+
 	// ~Begin FRenderResource interface.
 
 	/**
-	 * Initialize the different buffers used in this render resource. 
+	 * Initialize the different buffers used in this render resource.
 	 */
 	virtual void InitRHI(FRHICommandListBase& RHICmdList) override;
 
-	/** 
-	 * Release all buffers used in this render resource.  
+	/**
+	 * Release all buffers used in this render resource.
 	 */
 	virtual void ReleaseRHI() override;
 	virtual FString GetFriendlyName() const override { return TEXT("Particle Upsampling Render Resources") ;};
 
 	// ~End FRenderResource interface.
 
-	/** 
-	 * Function for initializing a new Read-only buffer on the GPU 
+	/**
+	 * Function for initializing a new Read-only buffer on the GPU
 	 */
 	template <typename T>
 	FShaderResourceViewRHIRef InitSRVBuffer(
 		FRHICommandListBase& RHICmdList, const TCHAR* InDebugName, uint32 ElementCount);
 
-	/** 
-	 * Function for initializing a new Read/Write buffer on the GPU. 
+	/**
+	 * Function for initializing a new Read/Write buffer on the GPU.
 	 */
 	template <typename T>
 	FUnorderedAccessViewRHIRef InitUAVBuffer(
 		FRHICommandListBase& RHICmdList, const TCHAR* InDebugName, uint32 ElementCount);
 
-	/** 
-	 * Update the buffers for the coarse particles, releasing the old ones and creating new ones. 
+	/**
+	 * Update the buffers for the coarse particles, releasing the old ones and creating new ones.
 	 */
 	void UpdateCoarseParticleBuffer(
 		FRHICommandListBase& RHICmdList, const TArray<FCoarseParticle> CoarseParticleData);
 
-	/** 
-	 * Update the buffers for the hashtable, releasing the old ones and creating new ones. 
+	/**
+	 * Update the buffers for the hashtable, releasing the old ones and creating new ones.
 	 */
 	void UpdateHashTableBuffers(
 		FRHICommandListBase& RHICmdList, const TArray<FIntVector4> ActiveVoxelIndices);
 
-	/** 
-	 * Reference to the SRV buffer containing Coarse Particles. 
+	/**
+	 * Reference to the SRV buffer containing Coarse Particles.
 	 */
 	FShaderResourceViewRHIRef CoarseParticles;
 
@@ -137,18 +137,18 @@ struct AGXUNREALSHADERS_API FParticleUpsamplingBuffers : public FRenderResource
 	 */
 	uint32 CoarseParticlesCapacity {0};
 
-	/** 
-	 * Reference to the SRV buffer containing Active Voxels. 
+	/**
+	 * Reference to the SRV buffer containing Active Voxels.
 	 */
 	FShaderResourceViewRHIRef ActiveVoxelIndices;
 
-	/** 
-	 * Reference to the UAV buffer containing data for each voxel in the voxel grid. 
+	/**
+	 * Reference to the UAV buffer containing data for each voxel in the voxel grid.
 	 */
 	FUnorderedAccessViewRHIRef ActiveVoxelsTable;
 
 	/**
-	 * Reference to the UAV buffer containing data on which indices are 
+	 * Reference to the UAV buffer containing data on which indices are
 	 * occupied in the hashtable buffer.
 	 */
 	FUnorderedAccessViewRHIRef ActiveVoxelsTableOccupancy;
@@ -160,10 +160,10 @@ struct AGXUNREALSHADERS_API FParticleUpsamplingBuffers : public FRenderResource
 };
 
 /**
- * Struct containing the data from the simulation that is used to be able to 
+ * Struct containing the data from the simulation that is used to be able to
  * perform particle upsampling.
  */
-struct AGXUNREALSHADERS_API FParticleUpsamplingSimulationData
+struct AGXUNREAL_API FParticleUpsamplingSimulationData
 {
 	FParticleUpsamplingSimulationData()
 	{
@@ -180,12 +180,12 @@ struct AGXUNREALSHADERS_API FParticleUpsamplingSimulationData
 	int TableSize = 0;
 };
 
-/** 
+/**
  * Struct for handling all the data and buffers for the particle upsampling
  * data interface. This struct will be passed as the instanced data between
  * the game thread and render thread.
  */
-struct AGXUNREALSHADERS_API FParticleUpsamplingDataHandler
+struct AGXUNREAL_API FParticleUpsamplingDataHandler
 {
 	static const uint32 INITIAL_COARSE_PARTICLE_BUFFER_SIZE = 1024;
 	static const uint32 INITIAL_ACTIVE_VOXEL_BUFFER_SIZE = 1024;

--- a/Source/AGXUnrealShaders/AGXUnrealShaders.Build.cs
+++ b/Source/AGXUnrealShaders/AGXUnrealShaders.Build.cs
@@ -20,10 +20,5 @@ public class AGXUnrealShaders : ModuleRules
             "RHI",
             "Projects"
         });
-
-        PrivateDependencyModuleNames.AddRange(new string[]
-        {
-            "Niagara"
-        });
     }
 }


### PR DESCRIPTION
Move particle upsampling classes from AGXUnrealShaders to AGXUnreal

Needed because AGXUnrealShaders has LoadingPhase PostConfigInit while Niagara has LoadingPhase PreDefault, which is later than PostConfigInit. Not sure exactly why, but this causes Unreal to not reliably prepare the Niagara load path before loading AGXUnrealShaders, resulting in "libNiagara.so not found" errors from dlopen when loading AGXUnrealShaders. It sometimes works, sometimes doesn't. By moving all Niagara code out of AGXUnrealShaders and into a later-loaded module, AGXUnreal, we are guaranteed to always have the Niagara library available when loading the Niagara-using code, and the shader directory register code can remain in the PostConfigInit module where it needs to be.