### PR TITLE
fix/ini-in-package

### DIFF
--- a/Config/FilterPlugin.ini
+++ b/Config/FilterPlugin.ini
@@ -2,6 +2,7 @@
 ; This section lists additional files which will be packaged along with your plugin. Paths should be listed relative to the root plugin directory, and
 ; may include "...", "*", and "?" wildcards to match directories, files, and individual characters respectively.
 license/README.md
+Config/
 ;
 ; Examples:
 ;    /README.txt


### PR DESCRIPTION
Add `Config` to `Config/FilterPlugin.ini` so that our `DefaultAGXUnreal.ini` is included in packages.