### PR TITLE
Add support for Hydro/Aero module

### DIFF
--- a/Source/AGXUnreal/Private/Materials/AGX_ShapeMaterial.cpp
+++ b/Source/AGXUnreal/Private/Materials/AGX_ShapeMaterial.cpp
@@ -400,7 +400,7 @@ UAGX_ShapeMaterial* UAGX_ShapeMaterial::CreateInstanceFromAsset(
 	const FString InstanceName = Source->GetName() + "_Instance";
 
 	UAGX_ShapeMaterial* NewInstance = NewObject<UAGX_ShapeMaterial>(
-		GetTransientPackage(), UAGX_ShapeMaterial::StaticClass(), *InstanceName, RF_Transient);
+		GetTransientPackage(), Source->GetClass(), *InstanceName, RF_Transient);
 	NewInstance->Asset = Source;
 	NewInstance->CopyShapeMaterialProperties(Source);
 	NewInstance->CreateNative(PlayingWorld);

--- a/Source/AGXUnreal/Private/Model/AGX_DynamicWaterComponent.cpp
+++ b/Source/AGXUnreal/Private/Model/AGX_DynamicWaterComponent.cpp
@@ -1,0 +1,177 @@
+﻿// Copyright 2026, Algoryx Simulation AB.
+
+
+#include "Model/AGX_DynamicWaterComponent.h"
+
+#include "AGX_LogCategory.h"
+#include "AGX_Simulation.h"
+#include "Model/AGX_WindAndWaterControllerSubsystemBase.h"
+#include "Shapes/AGX_ShapeComponent.h"
+#include "Utilities/AGX_StringUtilities.h"
+
+namespace
+{
+	class CustomDynamicWaterBarrier : public FDynamicWaterBarrier
+	{
+	public:
+		CustomDynamicWaterBarrier(const UAGX_DynamicWaterComponent& Owner) : Owner_(Owner)
+		{
+		}
+
+		virtual double FindHeightFromSurface(const FVector& WorldPoint, const FVector& UpVector, const double& Time) const override
+		{
+			return Owner_.FindHeightFromSurface(WorldPoint, UpVector, Time);
+		}
+
+		virtual double GetDensity() const override
+		{
+			return Owner_.GetDensity();
+		}
+
+		virtual FVector GetVelocity(const FVector& WorldPoint) const override
+		{
+			return Owner_.GetVelocity(WorldPoint);
+		}
+
+		const UAGX_DynamicWaterComponent& Owner_;
+	};
+}
+
+// Sets default values for this component's properties
+UAGX_DynamicWaterComponent::UAGX_DynamicWaterComponent()
+{
+	// Set this component to be initialized when the game starts, and to be ticked every frame.  You can turn these features
+	// off to improve performance if you don't need them.
+	PrimaryComponentTick.bCanEverTick = false;
+
+	// ...
+}
+
+FDynamicWaterBarrier* UAGX_DynamicWaterComponent::GetOrCreateNative()
+{
+	if (!HasNative())
+	{
+		if (GIsReconstructingBlueprintInstances)
+		{
+			// We're in a very bad situation. Someone need this Component's native but if we're in
+			// the middle of a RerunConstructionScripts and this Component haven't been given its
+			// Native yet then there isn't much we can do. We can't create a new one since we will
+			// be given the actual Native soon, but we also can't return the actual Native right now
+			// because it hasn't been restored from the Component Instance Data yet.
+			//
+			// For now we simply die in non-shipping (checkNoEntry is active) so unit tests will
+			// detect this situation, and log error and return nullptr otherwise, so that the
+			// application can at least keep running. It is unlikely that the simulation will behave
+			// as intended.
+			checkNoEntry();
+			UE_LOG(
+				LogAGX, Error,
+				TEXT("A request for the AGX Dynamics instance for water wrapper '%s' in '%s' was made "
+					"but we are in the middle of a Blueprint Reconstruction and the requested "
+					"instance has not yet been restored. The instance cannot be returned, which "
+					"may lead to incorrect scene configuration."),
+				*GetName(), *GetLabelSafe(GetOwner()));
+			return nullptr;
+		}
+
+		InitializeNative();
+	}
+	check(HasNative()); /// \todo Consider better error handling than 'check'.
+	return NativeBarrier.Get();
+}
+
+FDynamicWaterBarrier* UAGX_DynamicWaterComponent::GetNative()
+{
+	if (!HasNative())
+	{
+		return nullptr;
+	}
+	return NativeBarrier.Get();
+}
+
+const FDynamicWaterBarrier* UAGX_DynamicWaterComponent::GetNative() const
+{
+	if (!HasNative())
+	{
+		return nullptr;
+	}
+	return NativeBarrier.Get();
+}
+
+bool UAGX_DynamicWaterComponent::HasNative() const
+{
+	return NativeBarrier == nullptr ? false : NativeBarrier->HasNative();
+}
+
+uint64 UAGX_DynamicWaterComponent::GetNativeAddress() const
+{
+	check(!HasNative());
+	return static_cast<uint64>(NativeBarrier->GetNativeAddress());
+}
+
+void UAGX_DynamicWaterComponent::SetNativeAddress(uint64 NativeAddress)
+{
+	check(!HasNative());
+	NativeBarrier->SetNativeAddress(static_cast<uintptr_t>(NativeAddress));
+}
+
+// Called when the game starts
+void UAGX_DynamicWaterComponent::BeginPlay()
+{
+	Super::BeginPlay();
+	if (GIsReconstructingBlueprintInstances) return;
+
+	GetOrCreateNative();
+	const UAGX_Simulation* Simulation = UAGX_Simulation::GetFrom(this);
+	if (Simulation == nullptr)
+	{
+		UE_LOG(
+			LogAGX, Error,
+			TEXT("Shape '%s' in '%s' tried to get Simulation, but UAGX_Simulation::GetFrom "
+				"returned nullptr."),
+			*GetName(), *GetLabelSafe(GetOwner()));
+		return;
+	}
+
+	UAGX_ShapeComponent* ParentShape = Cast<UAGX_ShapeComponent>(GetAttachParent());
+	if (ParentShape == nullptr) return;
+
+	if (const auto WindAndWaterControllerSubsystem = UAGX_WindAndWaterControllerSubsystemBase::GetFrom(this))
+	{
+		WindAndWaterControllerSubsystem->SetWaterWrapper(ParentShape, this);
+		WindAndWaterControllerSubsystem->SetWaterFlowGenerator(ParentShape, this);
+	}
+}
+
+void UAGX_DynamicWaterComponent::EndPlay(EEndPlayReason::Type Reason)
+{
+	Super::EndPlay(Reason);
+	if (GIsReconstructingBlueprintInstances) return;
+	if (HasNative())
+	{
+		NativeBarrier->ReleaseNative();
+	}
+}
+
+double UAGX_DynamicWaterComponent::FindHeightFromSurface(const FVector& WorldPoint, const FVector& UpVector, const double& Time) const
+{
+	return WorldPoint.Z;
+}
+
+double UAGX_DynamicWaterComponent::GetDensity() const
+{
+	return 1000.0;
+}
+
+FVector UAGX_DynamicWaterComponent::GetVelocity(const FVector& WorldPoint) const
+{
+	return FVector::Zero();
+}
+
+void UAGX_DynamicWaterComponent::InitializeNative()
+{
+	check(!HasNative());
+
+	NativeBarrier = MakeUnique<CustomDynamicWaterBarrier>(*this);
+	NativeBarrier->AllocateNative();
+}

--- a/Source/AGXUnreal/Private/Model/AGX_WindAndWaterAwareShapeMaterial.cpp
+++ b/Source/AGXUnreal/Private/Model/AGX_WindAndWaterAwareShapeMaterial.cpp
@@ -1,0 +1,14 @@
+﻿// Copyright 2026, Algoryx Simulation AB.
+
+#include "Model/AGX_WindAndWaterAwareShapeMaterial.h"
+
+void UAGX_WindAndWaterAwareShapeMaterial::CopyShapeMaterialProperties(const UAGX_ShapeMaterial* Source)
+{
+	Super::CopyShapeMaterialProperties(Source);
+	if (auto SubSource = Cast<UAGX_WindAndWaterAwareShapeMaterial>(Source))
+	{
+		bIsWaterGeometry = SubSource->bIsWaterGeometry;
+		HydroParameters = SubSource->HydroParameters;
+		AeroParameters = SubSource->AeroParameters;
+	}
+}

--- a/Source/AGXUnreal/Private/Model/AGX_WindAndWaterControllerSubsystemBase.cpp
+++ b/Source/AGXUnreal/Private/Model/AGX_WindAndWaterControllerSubsystemBase.cpp
@@ -1,0 +1,165 @@
+﻿// Copyright 2026, Algoryx Simulation AB.
+
+
+#include "Model/AGX_WindAndWaterControllerSubsystemBase.h"
+
+#include "AGX_Simulation.h"
+#include "Model/AGX_DynamicWaterComponent.h"
+#include "Model/AGX_WindAndWaterAwareShapeMaterial.h"
+#include "Model/WindAndWaterControllerBarrier.h"
+#include "Model/WindAndWaterParametersEnums.h"
+#include "Shapes/AGX_BoxShapeComponent.h"
+#include "Shapes/AGX_HeightFieldShapeComponent.h"
+#include "Shapes/AGX_ShapeComponent.h"
+#include "Shapes/AGX_SphereShapeComponent.h"
+#include "Wire/AGX_WireComponent.h"
+
+bool UAGX_WindAndWaterControllerSubsystemBase::HasNative() const
+{
+	return NativeWindAndWaterControllerBarrier.HasNative();
+}
+
+uint64 UAGX_WindAndWaterControllerSubsystemBase::GetNativeAddress() const
+{
+	return static_cast<uint64>(NativeWindAndWaterControllerBarrier.GetNativeAddress());
+}
+
+void UAGX_WindAndWaterControllerSubsystemBase::SetNativeAddress(uint64 NativeAddress)
+{
+	check(!HasNative());
+	NativeWindAndWaterControllerBarrier.SetNativeAddress(static_cast<uintptr_t>(NativeAddress));
+}
+
+UAGX_WindAndWaterControllerSubsystemBase* UAGX_WindAndWaterControllerSubsystemBase::GetFrom(const UActorComponent* Component)
+{
+	return Component ? GetFrom(Component->GetOwner()) : nullptr;
+}
+
+UAGX_WindAndWaterControllerSubsystemBase* UAGX_WindAndWaterControllerSubsystemBase::GetFrom(const AActor* Actor)
+{
+	return Actor ? Actor->GetGameInstance()->GetSubsystem<UAGX_WindAndWaterControllerSubsystemBase>() : nullptr;
+}
+
+void UAGX_WindAndWaterControllerSubsystemBase::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+	Collection.InitializeDependency(UAGX_Simulation::StaticClass());
+	if (!HasNative())
+	{
+		NativeWindAndWaterControllerBarrier.AllocateNative();
+	}
+	
+	if (UAGX_Simulation* Sim = GetGameInstance()->GetSubsystem<UAGX_Simulation>())
+	{
+		if (Sim->HasNative())
+		{
+			Sim->GetNative()->Add(NativeWindAndWaterControllerBarrier);
+		}
+	}
+}
+
+void UAGX_WindAndWaterControllerSubsystemBase::Deinitialize()
+{
+	Super::Deinitialize();
+	
+	NativeWindAndWaterControllerBarrier.ReleaseNative();
+}
+
+FWindAndWaterControllerBarrier* UAGX_WindAndWaterControllerSubsystemBase::GetNative()
+{
+	return HasNative() ? &NativeWindAndWaterControllerBarrier : nullptr;
+}
+
+bool UAGX_WindAndWaterControllerSubsystemBase::AddWater(UAGX_ShapeComponent* Shape)
+{
+	return HasNative() ? NativeWindAndWaterControllerBarrier.AddWater(Shape->GetOrCreateNative()) : false;
+}
+
+bool UAGX_WindAndWaterControllerSubsystemBase::SetEnableAerodynamics(UAGX_ShapeComponent* Shape, bool bEnabled)
+{
+	return HasNative() ? NativeWindAndWaterControllerBarrier.SetEnableAerodynamics(Shape->GetOrCreateNative(), bEnabled) : false;
+}
+
+bool UAGX_WindAndWaterControllerSubsystemBase::SetEnableAerodynamics(UAGX_WireComponent* Wire, bool bEnabled)
+{
+	return HasNative() ? NativeWindAndWaterControllerBarrier.SetEnableAerodynamics(Wire->GetOrCreateNative(), bEnabled) : false;
+}
+
+void UAGX_WindAndWaterControllerSubsystemBase::SetHydrodynamicParameters(UAGX_ShapeComponent* Shape, EWindAndWaterParametersCoefficient Coefficient, double Value)
+{
+	if (HasNative())
+	{
+		NativeWindAndWaterControllerBarrier.GetOrCreateHydrodynamicsParameters(Shape->GetOrCreateNative()).SetCoefficient(Coefficient, Value);
+	}
+}
+
+void UAGX_WindAndWaterControllerSubsystemBase::SetHydrodynamicParameters(UAGX_ShapeComponent* Shape, EWindAndWaterShapeTessellation ShapeTessellation)
+{
+	if (HasNative())
+	{
+		NativeWindAndWaterControllerBarrier.GetOrCreateHydrodynamicsParameters(Shape->GetOrCreateNative()).SetShapeTessellation(ShapeTessellation);
+	}
+}
+
+void UAGX_WindAndWaterControllerSubsystemBase::SetAerodynamicParameters(UAGX_ShapeComponent* Shape, EWindAndWaterParametersCoefficient Coefficient, double Value)
+{
+	if (HasNative())
+	{
+		NativeWindAndWaterControllerBarrier.GetOrCreateAerodynamicsParameters(Shape->GetOrCreateNative()).SetCoefficient(Coefficient, Value);
+	}
+}
+
+void UAGX_WindAndWaterControllerSubsystemBase::SetAerodynamicParameters(UAGX_ShapeComponent* Shape, EWindAndWaterShapeTessellation ShapeTessellation)
+{
+	if (HasNative())
+	{
+		NativeWindAndWaterControllerBarrier.GetOrCreateAerodynamicsParameters(Shape->GetOrCreateNative()).SetShapeTessellation(ShapeTessellation);
+	}
+}
+
+bool UAGX_WindAndWaterControllerSubsystemBase::UpdateNativeWindAndWaterParameters(UAGX_ShapeComponent* Shape)
+{
+	if (!Shape) return false;
+
+	const UAGX_WindAndWaterAwareShapeMaterial* ShapeMaterial = Cast<UAGX_WindAndWaterAwareShapeMaterial>(Shape->ShapeMaterial);
+	if (!ShapeMaterial) return false;
+
+	if (ShapeMaterial->bIsWaterGeometry)
+	{
+		if (Shape->IsA(UAGX_BoxShapeComponent::StaticClass()) ||
+			Shape->IsA(UAGX_HeightFieldShapeComponent::StaticClass()) ||
+			Shape->IsA(UAGX_SphereShapeComponent::StaticClass()))
+		{
+			Shape->SetCanCollide(false);
+			return AddWater(Shape);
+		}
+	}
+
+	SetHydrodynamicParameters(Shape, EWindAndWaterParametersCoefficient::PRESSURE_DRAG, ShapeMaterial->HydroParameters.PressureDrag_);
+	SetHydrodynamicParameters(Shape, EWindAndWaterParametersCoefficient::VISCOUS_DRAG, ShapeMaterial->HydroParameters.ViscousDrag_);
+	SetHydrodynamicParameters(Shape, EWindAndWaterParametersCoefficient::LIFT, ShapeMaterial->HydroParameters.Lift_);
+	SetHydrodynamicParameters(Shape, EWindAndWaterParametersCoefficient::BUOYANCY, ShapeMaterial->HydroParameters.Buoyancy_);
+	SetHydrodynamicParameters(Shape, ShapeMaterial->HydroParameters.ShapeTessellation_);
+
+	SetAerodynamicParameters(Shape, EWindAndWaterParametersCoefficient::PRESSURE_DRAG, ShapeMaterial->AeroParameters.PressureDrag_);
+	SetAerodynamicParameters(Shape, EWindAndWaterParametersCoefficient::VISCOUS_DRAG, ShapeMaterial->AeroParameters.ViscousDrag_);
+	SetAerodynamicParameters(Shape, EWindAndWaterParametersCoefficient::LIFT, ShapeMaterial->AeroParameters.Lift_);
+	SetAerodynamicParameters(Shape, ShapeMaterial->AeroParameters.ShapeTessellation_);
+	return true;
+}
+
+void UAGX_WindAndWaterControllerSubsystemBase::SetWaterWrapper(UAGX_ShapeComponent* Shape, UAGX_DynamicWaterComponent* WaterWrapper)
+{
+	if (NativeWindAndWaterControllerBarrier.HasNative())
+	{
+		NativeWindAndWaterControllerBarrier.SetWaterWrapper(Shape->GetOrCreateNative(), WaterWrapper->GetOrCreateNative());
+	}
+}
+
+void UAGX_WindAndWaterControllerSubsystemBase::SetWaterFlowGenerator(UAGX_ShapeComponent* ParentShape, UAGX_DynamicWaterComponent* DynamicWater)
+{
+	if (NativeWindAndWaterControllerBarrier.HasNative())
+	{
+		NativeWindAndWaterControllerBarrier.SetWaterFlowGenerator(ParentShape->GetOrCreateNative(), DynamicWater->GetOrCreateNative());
+	}
+}

--- a/Source/AGXUnreal/Private/Shapes/AGX_ShapeComponent.cpp
+++ b/Source/AGXUnreal/Private/Shapes/AGX_ShapeComponent.cpp
@@ -14,6 +14,7 @@
 #include "Import/AGX_ImportContext.h"
 #include "Materials/AGX_ShapeMaterial.h"
 #include "Materials/ShapeMaterialBarrier.h"
+#include "Model/AGX_WindAndWaterControllerSubsystemBase.h"
 #include "Shapes/RenderDataBarrier.h"
 #include "Shapes/RenderMaterial.h"
 #include "Utilities/AGX_ImportRuntimeUtilities.h"
@@ -138,6 +139,12 @@ bool UAGX_ShapeComponent::UpdateNativeMaterial()
 	FShapeMaterialBarrier* MaterialBarrier = Instance->GetOrCreateShapeMaterialNative(World);
 	check(MaterialBarrier);
 	GetNative()->SetMaterial(*MaterialBarrier);
+	
+	if (const auto WindAndWaterSubsystem = UAGX_WindAndWaterControllerSubsystemBase::GetFrom(this))
+	{
+		WindAndWaterSubsystem->UpdateNativeWindAndWaterParameters(this);
+	}
+    
 	return true;
 }
 

--- a/Source/AGXUnreal/Public/Materials/AGX_ShapeMaterial.h
+++ b/Source/AGXUnreal/Public/Materials/AGX_ShapeMaterial.h
@@ -162,7 +162,7 @@ public:
 
 	bool IsInstance() const;
 
-	void CopyShapeMaterialProperties(const UAGX_ShapeMaterial* Source);
+	virtual void CopyShapeMaterialProperties(const UAGX_ShapeMaterial* Source);
 
 private:
 	void CreateNative(UWorld* PlayingWorld);

--- a/Source/AGXUnreal/Public/Model/AGX_DynamicWaterComponent.h
+++ b/Source/AGXUnreal/Public/Model/AGX_DynamicWaterComponent.h
@@ -1,0 +1,58 @@
+﻿// Copyright 2026, Algoryx Simulation AB.
+
+#pragma once
+
+// AGX Dynamics for Unreal includes.
+#include "AGX_NativeOwner.h"
+#include "Model/DynamicWaterBarrier.h"
+
+// Unreal Engine includes.
+#include "Components/SceneComponent.h"
+#include "CoreMinimal.h"
+
+#include "AGX_DynamicWaterComponent.generated.h"
+
+UCLASS(ClassGroup = "AGX", Category = "AGX", BlueprintType, Blueprintable,
+	meta = (BlueprintSpawnableComponent))
+class AGXUNREAL_API UAGX_DynamicWaterComponent : public USceneComponent, public IAGX_NativeOwner
+{
+	GENERATED_BODY()
+
+public:
+	// Sets default values for this component's properties
+	UAGX_DynamicWaterComponent();
+
+	/**
+	 * Get the Native Barrier. Create the native AGX Dynamics object if it does not
+	 * already exist.
+	 *
+	 * @return The Native Barrier for this controller.
+	 */
+	FDynamicWaterBarrier* GetOrCreateNative();
+
+	/// Return the native AGX Dynamics representation of this controller. May return nullptr.
+	FDynamicWaterBarrier* GetNative();
+
+	const FDynamicWaterBarrier* GetNative() const;
+
+	// ~Begin IAGX_NativeOwner interface.
+	virtual bool HasNative() const override;
+	virtual uint64 GetNativeAddress() const override;
+	virtual void SetNativeAddress(uint64 NativeAddress) override;
+
+protected:
+	// Called when the game starts
+	virtual void BeginPlay() override;
+	virtual void EndPlay(EEndPlayReason::Type Reason) override;
+
+public:
+	virtual double FindHeightFromSurface(const FVector& WorldPoint, const FVector& UpVector, const double& Time) const;
+	virtual double GetDensity() const;
+	virtual FVector GetVelocity(const FVector& WorldPoint) const;
+
+private:
+	// Create the native AGX Dynamics object.
+	void InitializeNative();
+
+	TUniquePtr<FDynamicWaterBarrier> NativeBarrier;
+};

--- a/Source/AGXUnreal/Public/Model/AGX_WindAndWaterAwareShapeMaterial.h
+++ b/Source/AGXUnreal/Public/Model/AGX_WindAndWaterAwareShapeMaterial.h
@@ -1,0 +1,53 @@
+﻿// Copyright Aker Solutions. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Materials/AGX_ShapeMaterial.h"
+#include "Model/WindAndWaterParametersEnums.h"
+#include "AGX_WindAndWaterAwareShapeMaterial.generated.h"
+
+class UAGX_WindAndWaterShapeRegistryComponent;
+/**
+ * Defines hydrodynamic and aerodynamic properties of AGX Shapes.
+ */
+USTRUCT(BlueprintType)
+struct FAGX_Ext_WindAndWaterParameters
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere)
+	double PressureDrag_ = 0.0;
+
+	UPROPERTY(EditAnywhere)
+	double ViscousDrag_ = 0.0;
+
+	UPROPERTY(EditAnywhere)
+	double Lift_ = 0.0;
+
+	UPROPERTY(EditAnywhere)
+	double Buoyancy_ = 1.0;
+	
+	UPROPERTY(EditAnywhere)
+	EWindAndWaterShapeTessellation ShapeTessellation_ = EWindAndWaterShapeTessellation::DEFAULT_TESSELLATION;
+};
+
+UCLASS(ClassGroup = "AGX", Category = "AGX", BlueprintType, Blueprintable,
+	AutoExpandCategories = ("Material Properties"))
+class AGXUNREAL_API UAGX_WindAndWaterAwareShapeMaterial : public UAGX_ShapeMaterial
+{
+	GENERATED_BODY()
+public:
+	UPROPERTY(EditAnywhere, Category="Material Properties | Wind And Water")
+	bool bIsWaterGeometry = false;
+	
+	UPROPERTY(EditAnywhere, Category="Material Properties | Wind And Water", meta=(EditCondition = "!bIsWaterGeometry", EditConditionHides))
+	FAGX_Ext_WindAndWaterParameters HydroParameters;
+
+	UPROPERTY(EditAnywhere, Category="Material Properties | Wind And Water", meta=(EditCondition = "!bIsWaterGeometry", EditConditionHides))
+	FAGX_Ext_WindAndWaterParameters AeroParameters;
+
+protected:
+	virtual void CopyShapeMaterialProperties(const UAGX_ShapeMaterial* Source) override;
+};
+

--- a/Source/AGXUnreal/Public/Model/AGX_WindAndWaterControllerSubsystemBase.h
+++ b/Source/AGXUnreal/Public/Model/AGX_WindAndWaterControllerSubsystemBase.h
@@ -1,0 +1,52 @@
+﻿// Copyright Aker Solutions. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "AGX_NativeOwner.h"
+#include "Model/WindAndWaterControllerBarrier.h"
+#include "AGX_WindAndWaterControllerSubsystemBase.generated.h"
+
+class UAGX_WireComponent;
+class UAGX_ShapeComponent;
+class UAGX_DynamicWaterComponent;
+
+/**
+ * A game instance subsystem that holds the agxModel::WindAndWaterController as a singleton.
+ * The native agxModel::WindAndWaterController is instanced and added to the agxSDK::Simulation during initialization.
+ */
+UCLASS(DisplayName="AGX Wind And Water Subsystem (Extension)", Abstract)
+class AGXUNREAL_API UAGX_WindAndWaterControllerSubsystemBase : public UGameInstanceSubsystem, public IAGX_NativeOwner
+{
+	GENERATED_BODY()
+
+public:
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+	virtual void Deinitialize() override;
+	FWindAndWaterControllerBarrier* GetNative();
+	
+	bool AddWater(UAGX_ShapeComponent* Shape);
+
+	bool SetEnableAerodynamics(UAGX_ShapeComponent* Shape, bool bEnabled);
+	bool SetEnableAerodynamics(UAGX_WireComponent* Wire, bool bEnabled);
+
+	void SetHydrodynamicParameters(UAGX_ShapeComponent* Shape, EWindAndWaterParametersCoefficient Coefficient, double Value);
+	void SetHydrodynamicParameters(UAGX_ShapeComponent* Shape, EWindAndWaterShapeTessellation ShapeTessellation);
+	void SetAerodynamicParameters(UAGX_ShapeComponent* Shape, EWindAndWaterParametersCoefficient Coefficient, double Value);
+	void SetAerodynamicParameters(UAGX_ShapeComponent* Shape, EWindAndWaterShapeTessellation ShapeTessellation);
+
+	void SetWaterWrapper(UAGX_ShapeComponent* Shape, UAGX_DynamicWaterComponent* WaterWrapper);
+	void SetWaterFlowGenerator(UAGX_ShapeComponent* ParentShape, UAGX_DynamicWaterComponent* DynamicWater);
+	virtual bool UpdateNativeWindAndWaterParameters(UAGX_ShapeComponent* Shape);
+	
+	virtual bool HasNative() const override;
+	virtual uint64 GetNativeAddress() const override;
+	virtual void SetNativeAddress(uint64 NativeAddress) override;
+
+	static UAGX_WindAndWaterControllerSubsystemBase* GetFrom(const UActorComponent* Component);
+
+	static UAGX_WindAndWaterControllerSubsystemBase* GetFrom(const AActor* Actor);
+
+private:
+	FWindAndWaterControllerBarrier NativeWindAndWaterControllerBarrier;
+};

--- a/Source/AGXUnrealBarrier/Private/AGXBarrierFactories.cpp
+++ b/Source/AGXUnrealBarrier/Private/AGXBarrierFactories.cpp
@@ -225,3 +225,8 @@ FTrackBarrier AGXBarrierFactories::CreateTrackBarrier(agxVehicle::Track* Track)
 {
 	return {std::make_unique<FTrackRef>(Track)};
 }
+
+FWindAndWaterParametersBarrier AGXBarrierFactories::CreateWindAndWaterParametersBarrier(agxModel::WindAndWaterParameters* WindAndWaterParameters)
+{
+	return {std::make_unique<FWindAndWaterParametersRef>(WindAndWaterParameters)};
+}

--- a/Source/AGXUnrealBarrier/Private/AGXBarrierFactories.h
+++ b/Source/AGXUnrealBarrier/Private/AGXBarrierFactories.h
@@ -20,6 +20,7 @@
 #include "Materials/ContactMaterialBarrier.h"
 #include "Materials/ShapeMaterialBarrier.h"
 #include "Materials/TerrainMaterialBarrier.h"
+#include "Model/WindAndWaterParametersBarrier.h"
 #include "RigidBodyBarrier.h"
 #include "Sensors/RtAmbientMaterialBarrier.h"
 #include "Shapes/AnyShapeBarrier.h"
@@ -78,6 +79,7 @@ namespace agxCollide
 namespace agxModel
 {
 	class TwoBodyTire;
+	class WindAndWaterParameters;
 }
 
 namespace agxTerrain
@@ -189,6 +191,8 @@ namespace AGXBarrierFactories
 	FShovelBarrier CreateShovelBarrier(agxTerrain::Shovel* Shovel);
 
 	FSteeringBarrier CreateSteeringBarrier(agxVehicle::Steering* Steering);
-
+	
+	FWindAndWaterParametersBarrier CreateWindAndWaterParametersBarrier(agxModel::WindAndWaterParameters* WindAndWaterParameters);
+	
 	FTrackBarrier CreateTrackBarrier(agxVehicle::Track* Track);
 }

--- a/Source/AGXUnrealBarrier/Private/Model/DynamicWaterBarrier.cpp
+++ b/Source/AGXUnrealBarrier/Private/Model/DynamicWaterBarrier.cpp
@@ -1,0 +1,142 @@
+﻿// Copyright 2026, Algoryx Simulation AB.
+
+#include "Model/DynamicWaterBarrier.h"
+
+// AGX Dynamics for Unreal includes.
+#include "BarrierOnly/AGXRefs.h"
+#include "BarrierOnly/AGXTypeConversions.h"
+
+// AGX Dynamics includes.
+#include "BeginAGXIncludes.h"
+#include <agxModel/WindAndWaterController.h>
+#include "EndAGXIncludes.h"
+
+namespace
+{
+	class CustomWaterWrapper : public agxModel::WaterWrapper
+	{
+	public:
+		CustomWaterWrapper(const FDynamicWaterBarrier& Owner): Owner_(Owner)
+		{
+		}
+
+		virtual agx::Real findHeightFromSurface(const agx::Vec3& worldPoint, const agx::Vec3& upVector, const agx::TimeStamp& t) const override
+		{
+			return ConvertToAGX(Owner_.FindHeightFromSurface(ConvertDisplacement(worldPoint), ConvertDisplacement(upVector), t));
+		}
+
+		virtual agx::Real getDensity() const override
+		{
+			return ConvertToAGX(Owner_.GetDensity());
+		}
+
+		virtual agx::Vec3 getVelocity(const agx::Vec3& worldPoint) const override
+		{
+			return ConvertVector(Owner_.GetVelocity(ConvertVector(worldPoint)));
+		}
+
+		const FDynamicWaterBarrier& Owner_;
+	};
+
+	class CustomWaterFlowGenerator : public agxModel::WindAndWaterController::WaterFlowGenerator
+	{
+	public:
+		CustomWaterFlowGenerator(const FDynamicWaterBarrier& Owner): Owner_(Owner)
+		{
+		}
+
+		virtual agx::Vec3 getVelocity(const agx::Vec3& worldPoint) const override
+		{
+			return ConvertVector(Owner_.GetVelocity(ConvertVector(worldPoint)));
+		}
+
+		const FDynamicWaterBarrier& Owner_;
+	};
+}
+
+
+FDynamicWaterBarrier::FDynamicWaterBarrier()
+	: NativeRef{new FDynamicWaterRef}
+{
+}
+
+FDynamicWaterBarrier::FDynamicWaterBarrier(std::unique_ptr<FDynamicWaterRef> Native)
+	: NativeRef{std::move(Native)}
+{
+	check(NativeRef->NativeWaterWrapper->is<agxModel::WaterWrapper>());
+	check(NativeRef->NativeWaterFlowGenerator->is<agxModel::WindAndWaterController::WaterFlowGenerator>());
+}
+
+FDynamicWaterBarrier::FDynamicWaterBarrier(FDynamicWaterBarrier&& Other) noexcept
+	: NativeRef{std::move(Other.NativeRef)}
+{
+	Other.NativeRef.reset(new FDynamicWaterRef);
+}
+
+FDynamicWaterBarrier::~FDynamicWaterBarrier()
+{
+	// Must provide a destructor implementation in the .cpp file because the
+	// std::unique_ptr NativeRef's destructor must be able to see the definition,
+	// not just the forward declaration, of FExt_WaterWrapperRef.
+}
+
+bool FDynamicWaterBarrier::HasNative() const
+{
+	return NativeRef->NativeWaterWrapper != nullptr || NativeRef->NativeWaterFlowGenerator != nullptr;
+}
+
+void FDynamicWaterBarrier::AllocateNative()
+{
+	check(!HasNative());
+	NativeRef.reset(new FDynamicWaterRef(new CustomWaterWrapper(*this), new CustomWaterFlowGenerator(*this)));
+}
+
+FDynamicWaterRef* FDynamicWaterBarrier::GetNative()
+{
+	check(HasNative());
+	return NativeRef.get();
+}
+
+const FDynamicWaterRef* FDynamicWaterBarrier::GetNative() const
+{
+	check(HasNative());
+	return NativeRef.get();
+}
+
+uintptr_t FDynamicWaterBarrier::GetNativeAddress() const
+{
+	if (!HasNative())
+	{
+		return 0;
+	}
+
+	return reinterpret_cast<uintptr_t>(NativeRef->NativeWaterWrapper.get());
+}
+
+void FDynamicWaterBarrier::SetNativeAddress(uintptr_t NativeAddress)
+{
+	if (NativeAddress == GetNativeAddress())
+	{
+		return;
+	}
+
+	if (HasNative())
+	{
+		this->ReleaseNative();
+	}
+
+	if (NativeAddress == 0)
+	{
+		NativeRef.reset(new FDynamicWaterRef(nullptr, nullptr));
+		return;
+	}
+	
+	NativeRef.reset(new FDynamicWaterRef(
+		reinterpret_cast<agxModel::WaterWrapper*>(NativeAddress),
+		nullptr));
+}
+
+void FDynamicWaterBarrier::ReleaseNative()
+{
+	NativeRef.reset(new FDynamicWaterRef(nullptr, nullptr));
+}

--- a/Source/AGXUnrealBarrier/Private/Model/WindAndWaterControllerBarrier.cpp
+++ b/Source/AGXUnrealBarrier/Private/Model/WindAndWaterControllerBarrier.cpp
@@ -1,0 +1,150 @@
+﻿// Copyright 2026, Algoryx Simulation AB.
+
+#include "Model/WindAndWaterControllerBarrier.h"
+
+// AGX Dynamics for Unreal includes.
+#include "AGXBarrierFactories.h"
+#include "BarrierOnly/AGXRefs.h"
+#include "Model/DynamicWaterBarrier.h"
+
+// AGX Dynamics includes.
+#include "BeginAGXIncludes.h"
+#include <agxModel/WindAndWaterController.h>
+#include "EndAGXIncludes.h"
+
+FWindAndWaterControllerBarrier::FWindAndWaterControllerBarrier()
+	: NativeRef{new FWindAndWaterControllerRef}
+{
+}
+
+FWindAndWaterControllerBarrier::FWindAndWaterControllerBarrier(std::unique_ptr<FWindAndWaterControllerRef> Native)
+	: NativeRef{std::move(Native)}
+{
+	check(NativeRef->Native->is<agxModel::WindAndWaterController>());
+}
+
+FWindAndWaterControllerBarrier::FWindAndWaterControllerBarrier(FWindAndWaterControllerBarrier&& Other) noexcept
+	: NativeRef{std::move(Other.NativeRef)}
+{
+	Other.NativeRef.reset(new FWindAndWaterControllerRef);
+}
+
+FWindAndWaterControllerBarrier::~FWindAndWaterControllerBarrier()
+{
+	// Must provide a destructor implementation in the .cpp file because the
+	// std::unique_ptr NativeRef's destructor must be able to see the definition,
+	// not just the forward declaration, of FWindAndWaterControllerRef.
+}
+
+bool FWindAndWaterControllerBarrier::HasNative() const
+{
+	return NativeRef->Native != nullptr;
+}
+
+void FWindAndWaterControllerBarrier::AllocateNative()
+{
+	check(!HasNative());
+	NativeRef->Native = new agxModel::WindAndWaterController();
+}
+
+FWindAndWaterControllerRef* FWindAndWaterControllerBarrier::GetNative()
+{
+	check(HasNative());
+	return NativeRef.get();
+}
+
+const FWindAndWaterControllerRef* FWindAndWaterControllerBarrier::GetNative() const
+{
+	check(HasNative());
+	return NativeRef.get();
+}
+
+uintptr_t FWindAndWaterControllerBarrier::GetNativeAddress() const
+{
+	if (!HasNative())
+	{
+		return 0;
+	}
+
+	return reinterpret_cast<uintptr_t>(NativeRef->Native.get());
+}
+
+void FWindAndWaterControllerBarrier::SetNativeAddress(uintptr_t NativeAddress)
+{
+	if (NativeAddress == GetNativeAddress())
+	{
+		return;
+	}
+
+	if (HasNative())
+	{
+		this->ReleaseNative();
+	}
+
+	if (NativeAddress == 0)
+	{
+		NativeRef->Native = nullptr;
+		return;
+	}
+
+	NativeRef->Native = reinterpret_cast<agxModel::WindAndWaterController*>(NativeAddress);
+}
+
+void FWindAndWaterControllerBarrier::ReleaseNative()
+{
+	NativeRef->Native = nullptr;
+}
+
+FWindAndWaterParametersBarrier FWindAndWaterControllerBarrier::GetOrCreateHydrodynamicsParameters(FShapeBarrier* Shape) const
+{
+	check(HasNative());
+	return AGXBarrierFactories::CreateWindAndWaterParametersBarrier(NativeRef->Native->getOrCreateHydrodynamicsParameters(Shape->GetNative()->NativeShape));
+}
+
+FWindAndWaterParametersBarrier FWindAndWaterControllerBarrier::GetOrCreateHydrodynamicsParameters(FWireBarrier* Wire) const
+{
+	check(HasNative());
+	return AGXBarrierFactories::CreateWindAndWaterParametersBarrier(NativeRef->Native->getOrCreateAerodynamicsParameters(Wire->GetNative()->Native));
+}
+
+FWindAndWaterParametersBarrier FWindAndWaterControllerBarrier::GetOrCreateAerodynamicsParameters(FShapeBarrier* Shape) const
+{
+	check(HasNative());
+	return AGXBarrierFactories::CreateWindAndWaterParametersBarrier(NativeRef->Native->getOrCreateAerodynamicsParameters(Shape->GetNative()->NativeShape));
+}
+
+FWindAndWaterParametersBarrier FWindAndWaterControllerBarrier::GetOrCreateAerodynamicsParameters(FWireBarrier* Wire) const
+{
+	check(HasNative());
+	return AGXBarrierFactories::CreateWindAndWaterParametersBarrier(NativeRef->Native->getOrCreateAerodynamicsParameters(Wire->GetNative()->Native));
+}
+
+bool FWindAndWaterControllerBarrier::SetEnableAerodynamics(FShapeBarrier* Shape, bool bEnabled)
+{
+	check(HasNative());
+	return NativeRef->Native->setEnableAerodynamics(Shape->GetNative()->NativeGeometry, bEnabled);
+}
+
+bool FWindAndWaterControllerBarrier::SetEnableAerodynamics(FWireBarrier* Wire, bool bEnabled)
+{
+	check(HasNative());
+	return NativeRef->Native->setEnableAerodynamics(Wire->GetNative()->Native, bEnabled);
+}
+
+bool FWindAndWaterControllerBarrier::AddWater(const FShapeBarrier* Shape)
+{
+	check(HasNative());
+	return GetNative()->Native->addWater(Shape->GetNative()->NativeGeometry);
+}
+
+bool FWindAndWaterControllerBarrier::SetWaterWrapper(FShapeBarrier* Shape, FDynamicWaterBarrier* DynamicWater)
+{
+	check(HasNative());
+	return GetNative()->Native->setWaterWrapper(Shape->GetNative()->NativeGeometry, DynamicWater->GetNative()->NativeWaterWrapper);
+}
+
+bool FWindAndWaterControllerBarrier::SetWaterFlowGenerator(FShapeBarrier* Shape, FDynamicWaterBarrier* DynamicWater)
+{
+	check(HasNative());
+	return GetNative()->Native->setWaterFlowGenerator(Shape->GetNative()->NativeGeometry, DynamicWater->GetNative()->NativeWaterFlowGenerator);
+}

--- a/Source/AGXUnrealBarrier/Private/Model/WindAndWaterParametersBarrier.cpp
+++ b/Source/AGXUnrealBarrier/Private/Model/WindAndWaterParametersBarrier.cpp
@@ -1,0 +1,111 @@
+﻿// Copyright 2026, Algoryx Simulation AB.
+
+#include "Model/WindAndWaterParametersBarrier.h"
+
+// AGX Dynamics for Unreal includes.
+#include "BarrierOnly/AGXRefs.h"
+#include "BarrierOnly/AGXTypeConversions.h"
+#include "Model/WindAndWaterControllerBarrier.h"
+#include "Model/WindAndWaterParametersEnums.h"
+
+// AGX Dynamics includes.
+#include "BeginAGXIncludes.h"
+#include <agxModel/WindAndWaterParameters.h>
+#include "EndAGXIncludes.h"
+
+FWindAndWaterParametersBarrier::FWindAndWaterParametersBarrier()
+	: NativeRef{new FWindAndWaterParametersRef}
+{
+}
+
+FWindAndWaterParametersBarrier::FWindAndWaterParametersBarrier(std::unique_ptr<FWindAndWaterParametersRef> Native)
+	: NativeRef{std::move(Native)}
+{
+	check(NativeRef->Native->is<agxModel::WindAndWaterParameters>());
+}
+
+FWindAndWaterParametersBarrier::FWindAndWaterParametersBarrier(FWindAndWaterParametersBarrier&& Other) noexcept
+	: NativeRef{std::move(Other.NativeRef)}
+{
+	Other.NativeRef.reset(new FWindAndWaterParametersRef);
+}
+
+FWindAndWaterParametersBarrier::~FWindAndWaterParametersBarrier()
+{
+	// Must provide a destructor implementation in the .cpp file because the
+	// std::unique_ptr NativeRef's destructor must be able to see the definition,
+	// not just the forward declaration, of FWindAndWaterParametersRef.
+}
+
+bool FWindAndWaterParametersBarrier::HasNative() const
+{
+	return NativeRef->Native != nullptr;
+}
+
+FWindAndWaterParametersRef* FWindAndWaterParametersBarrier::GetNative()
+{
+	check(HasNative());
+	return NativeRef.get();
+}
+
+const FWindAndWaterParametersRef* FWindAndWaterParametersBarrier::GetNative() const
+{
+	check(HasNative());
+	return NativeRef.get();
+}
+
+uintptr_t FWindAndWaterParametersBarrier::GetNativeAddress() const
+{
+	if (!HasNative())
+	{
+		return 0;
+	}
+
+	return reinterpret_cast<uintptr_t>(NativeRef->Native.get());
+}
+
+void FWindAndWaterParametersBarrier::SetNativeAddress(uintptr_t NativeAddress)
+{
+	if (NativeAddress == GetNativeAddress())
+	{
+		return;
+	}
+
+	if (HasNative())
+	{
+		this->ReleaseNative();
+	}
+
+	if (NativeAddress == 0)
+	{
+		NativeRef->Native = nullptr;
+		return;
+	}
+
+	NativeRef->Native = reinterpret_cast<agxModel::WindAndWaterParameters*>(NativeAddress);
+}
+
+void FWindAndWaterParametersBarrier::ReleaseNative()
+{
+	NativeRef->Native = nullptr;
+}
+
+void FWindAndWaterParametersBarrier::SetCoefficient(EWindAndWaterParametersCoefficient Coefficient, double Value) const
+{
+	NativeRef->Native->setCoefficient(Convert(Coefficient), Value);
+}
+
+void FWindAndWaterParametersBarrier::SetShapeTessellation(EWindAndWaterShapeTessellation ShapeTessellation) const
+{
+	NativeRef->Native->setShapeTessellationLevel(Convert(ShapeTessellation));
+}
+
+void FWindAndWaterParametersBarrier::SetHydrodynamicCoefficient(FWindAndWaterControllerBarrier* Controller, FRigidBodyBarrier* RigidBody, EWindAndWaterParametersCoefficient Coefficient, double Value)
+{
+	agxModel::HydrodynamicsParameters::setHydrodynamicCoefficient(Controller->GetNative()->Native, RigidBody->GetNative()->Native, Convert(Coefficient), Value);
+}
+
+void FWindAndWaterParametersBarrier::SetAerodynamicCoefficient(FWindAndWaterControllerBarrier* Controller, FRigidBodyBarrier* RigidBody, EWindAndWaterParametersCoefficient Coefficient, double Value)
+{
+	agxModel::HydrodynamicsParameters::setAerodynamicCoefficient(Controller->GetNative()->Native, RigidBody->GetNative()->Native, Convert(Coefficient), Value);
+}

--- a/Source/AGXUnrealBarrier/Private/SimulationBarrier.cpp
+++ b/Source/AGXUnrealBarrier/Private/SimulationBarrier.cpp
@@ -15,6 +15,7 @@
 #include "Constraints/ConstraintBarrier.h"
 #include "Materials/ContactMaterialBarrier.h"
 #include "Materials/ShapeMaterialBarrier.h"
+#include "Model/WindAndWaterControllerBarrier.h"
 #include "ObserverFrameBarrier.h"
 #include "RigidBodyBarrier.h"
 #include "Shapes/ShapeBarrier.h"
@@ -84,9 +85,15 @@ bool FSimulationBarrier::Add(FContactMaterialBarrier& ContactMaterial)
 	return NativeRef->Native->add(ContactMaterial.GetNative()->Native);
 }
 
-bool FSimulationBarrier::Add(FObserverFrameBarrier& Frame)
+bool FSimulationBarrier::Add(FWindAndWaterControllerBarrier& WindAnWaterController)
 {
 	check(HasNative());
+	check(WindAnWaterController.HasNative());
+	return NativeRef->Native->add(WindAnWaterController.GetNative()->Native);
+}
+
+bool FSimulationBarrier::Add(FObserverFrameBarrier& Frame)
+{
 	check(Frame.HasNative());
 	return NativeRef->Native->add(Frame.GetNative()->Native);
 }
@@ -180,6 +187,13 @@ bool FSimulationBarrier::Remove(FContactMaterialBarrier& ContactMaterial)
 	check(HasNative());
 	check(ContactMaterial.HasNative());
 	return NativeRef->Native->remove(ContactMaterial.GetNative()->Native);
+}
+
+bool FSimulationBarrier::Remove(FWindAndWaterControllerBarrier& WindAnWaterController)
+{
+	check(HasNative());
+	check(WindAnWaterController.HasNative());
+	return NativeRef->Native->remove(WindAnWaterController.GetNative()->Native);
 }
 
 bool FSimulationBarrier::Remove(FObserverFrameBarrier& Frame)

--- a/Source/AGXUnrealBarrier/Public/BarrierOnly/AGXRefs.h
+++ b/Source/AGXUnrealBarrier/Public/BarrierOnly/AGXRefs.h
@@ -15,6 +15,8 @@
 #include <agxCollide/Geometry.h>
 #include <agxCollide/Shape.h>
 #include <agxModel/Tire.h>
+#include <agxModel/WindAndWaterController.h>
+#include <agxModel/WindAndWaterParameters.h>
 #include <agxPlot/DataSeries.h>
 #include <agxPlot/System.h>
 #include <agxPlot/WebPlot.h>
@@ -288,6 +290,43 @@ struct FTireRef
 	FTireRef() = default;
 	FTireRef(agxModel::Tire* InNative)
 		: Native(InNative)
+	{
+	}
+};
+
+struct FWindAndWaterControllerRef
+{
+	agxModel::WindAndWaterControllerRef Native;
+
+	FWindAndWaterControllerRef() = default;
+
+	FWindAndWaterControllerRef(agxModel::WindAndWaterController* InNative)
+		: Native(InNative)
+	{
+	}
+};
+
+struct FWindAndWaterParametersRef
+{
+	agxModel::WindAndWaterParametersRef Native;
+
+	FWindAndWaterParametersRef() = default;
+
+	FWindAndWaterParametersRef(agxModel::WindAndWaterParameters* InNative)
+		: Native(InNative)
+	{
+	}
+};
+
+struct FDynamicWaterRef
+{
+	agxModel::WaterWrapperRef NativeWaterWrapper;
+	agxModel::WindAndWaterController::WaterFlowGeneratorRef NativeWaterFlowGenerator;
+
+	FDynamicWaterRef() = default;
+	FDynamicWaterRef(agxModel::WaterWrapper* InWrapper, agxModel::WindAndWaterController::WaterFlowGenerator* InNativeGenerator)
+		: NativeWaterWrapper(InWrapper),
+		  NativeWaterFlowGenerator(InNativeGenerator)
 	{
 	}
 };

--- a/Source/AGXUnrealBarrier/Public/BarrierOnly/AGXTypeConversions.h
+++ b/Source/AGXUnrealBarrier/Public/BarrierOnly/AGXTypeConversions.h
@@ -14,6 +14,7 @@
 #include "Constraints/AGX_ConstraintEnumsCommon.h"
 #include "Contacts/AGX_ContactEnums.h"
 #include "Materials/AGX_ContactMaterialEnums.h"
+#include "Model/WindAndWaterParametersEnums.h"
 #include "RigidBodyBarrier.h"
 #include "Sensors/AGX_CustomPatternInterval.h"
 #include "Sensors/AGX_LidarEnums.h"
@@ -47,6 +48,7 @@
 #include <agx/Vec3.h>
 #include <agxCollide/Contacts.h>
 #include <agxModel/TwoBodyTire.h>
+#include <agxModel/WindAndWaterParameters.h>
 #include <agxSensor/LidarModelOusterOS.h>
 #include <agxSensor/LidarRayAngleGaussianNoise.h>
 #include <agxSensor/LidarRayPatternGenerator.h>
@@ -1545,6 +1547,75 @@ inline agxVehicle::TrackWheel::Model Convert(EAGX_TrackWheelModel Model)
 					 "literal to an agxVehicle::TrackWheel::Model."));
 			return agxVehicle::TrackWheel::IDLER;
 	}
+}
+//
+// Enumerations, WindAndWater.
+//
+
+inline agxModel::WindAndWaterParameters::Coefficient Convert(EWindAndWaterParametersCoefficient Coefficient)
+{
+    switch (Coefficient)
+    {
+    case EWindAndWaterParametersCoefficient::PRESSURE_DRAG:
+        return agxModel::WindAndWaterParameters::Coefficient::PRESSURE_DRAG;
+    case EWindAndWaterParametersCoefficient::VISCOUS_DRAG:
+        return agxModel::WindAndWaterParameters::Coefficient::VISCOUS_DRAG;
+    case EWindAndWaterParametersCoefficient::LIFT:
+        return agxModel::WindAndWaterParameters::Coefficient::LIFT;
+    case EWindAndWaterParametersCoefficient::BUOYANCY:
+        return agxModel::WindAndWaterParameters::Coefficient::BUOYANCY;
+    default:
+        UE_LOG(
+            LogAGX, Error,
+            TEXT("Conversion failed: Tried to convert an EWindAndWaterParametersCoefficient "
+                "literal of unknown type to an agxModel::WindAndWaterParameters::Coefficient "
+                "literal. Returning agxModel::WindAndWaterParameters::Coefficient::PRESSURE_DRAG."));
+        return agxModel::WindAndWaterParameters::Coefficient::PRESSURE_DRAG;
+    }
+}
+
+inline agxModel::WindAndWaterParameters::ShapeTessellation Convert(EWindAndWaterShapeTessellation ShapeTessellation)
+{
+    switch (ShapeTessellation)
+    {
+    case EWindAndWaterShapeTessellation::LOW:
+        return agxModel::WindAndWaterParameters::ShapeTessellation::LOW;
+    case EWindAndWaterShapeTessellation::MEDIUM:
+        return agxModel::WindAndWaterParameters::ShapeTessellation::MEDIUM;
+    case EWindAndWaterShapeTessellation::HIGH:
+        return agxModel::WindAndWaterParameters::ShapeTessellation::HIGH;
+    case EWindAndWaterShapeTessellation::ULTRA_HIGH:
+        return agxModel::WindAndWaterParameters::ShapeTessellation::ULTRA_HIGH;
+    default:
+        UE_LOG(
+            LogAGX, Error,
+            TEXT("Conversion failed: Tried to convert an EAGX_Ext_WindAnWaterShapeTessellation "
+                "literal of unknown type to an agxModel::WindAndWaterParameters::ShapeTessellation "
+                "literal. Returning agxModel::WindAndWaterParameters::ShapeTessellation::DEFAULT_TESSELLATION."));
+        return agxModel::WindAndWaterParameters::ShapeTessellation::DEFAULT_TESSELLATION;
+    }
+}
+
+inline EWindAndWaterParametersCoefficient Convert(agxModel::WindAndWaterParameters::Coefficient Coefficient)
+{
+    switch (Coefficient)
+    {
+    case agxModel::WindAndWaterParameters::Coefficient::PRESSURE_DRAG:
+        return EWindAndWaterParametersCoefficient::PRESSURE_DRAG;
+    case agxModel::WindAndWaterParameters::Coefficient::VISCOUS_DRAG:
+        return EWindAndWaterParametersCoefficient::VISCOUS_DRAG;
+    case agxModel::WindAndWaterParameters::Coefficient::LIFT:
+        return EWindAndWaterParametersCoefficient::LIFT;
+    case agxModel::WindAndWaterParameters::Coefficient::BUOYANCY:
+        return EWindAndWaterParametersCoefficient::BUOYANCY;
+    default:
+        UE_LOG(
+            LogAGX, Error,
+            TEXT("Conversion failed: Tried to convert an agxModel::WindAndWaterParameters::Coefficient "
+                "literal of unknown type to an EWindAndWaterParametersCoefficient "
+                "literal. Returning EWindAndWaterParametersCoefficient::PressureDrag."));
+        return EWindAndWaterParametersCoefficient::PRESSURE_DRAG;
+    }
 }
 
 inline EAGX_MergedTrackNodeContactReduction Convert(

--- a/Source/AGXUnrealBarrier/Public/Model/DynamicWaterBarrier.h
+++ b/Source/AGXUnrealBarrier/Public/Model/DynamicWaterBarrier.h
@@ -1,0 +1,48 @@
+﻿// Copyright 2026, Algoryx Simulation AB.
+
+#pragma once
+
+// AGX Dynamics for Unreal includes.
+
+// Unreal Engine includes.
+
+// System includes.
+#include <memory>
+
+struct FDynamicWaterRef;
+/**
+ * Barrier between UAGX_Ext_WaterWrapperComponent and agxModel::WaterWrapper.
+ * UAGX_Ext_WaterWrapperComponent holds an instance of Ext_WaterWrapperBarrier
+ * and hidden behind the Ext_WaterWrapperBarrier is a agxModel::WaterWrapper.
+ * This allows UAGX_Ext_WaterWrapperComponent to interact with
+ * agxModel::WaterWrapper without including agx/RigidBody.h.
+ * This class handles all translation between Unreal Engine types and
+ * AGX Dynamics types, such as back and forth between FVector and agx::Vec3.
+ */
+class AGXUNREALBARRIER_API FDynamicWaterBarrier
+{
+public:
+	FDynamicWaterBarrier();
+	FDynamicWaterBarrier(std::unique_ptr<FDynamicWaterRef> Native);
+	FDynamicWaterBarrier(FDynamicWaterBarrier&& Other) noexcept;
+	virtual ~FDynamicWaterBarrier();
+
+	bool HasNative() const;
+	void AllocateNative();
+	void ReleaseNative();
+	FDynamicWaterRef* GetNative();
+	const FDynamicWaterRef* GetNative() const;
+
+	/// @return The address of the underlying AGX Dynamics object.
+	uintptr_t GetNativeAddress() const;
+
+	/// Re-assign this Barrier to the given native address. The address must be an existing AGX
+	/// Dynamics object of the correct type.
+	void SetNativeAddress(uintptr_t NativeAddress);
+	virtual double FindHeightFromSurface(const FVector& WorldPoint, const FVector& UpVector, const double& Time) const = 0;
+	virtual double GetDensity() const = 0;
+	virtual FVector GetVelocity(const FVector& WorldPoint) const = 0;
+
+protected:
+	std::unique_ptr<FDynamicWaterRef> NativeRef;
+};

--- a/Source/AGXUnrealBarrier/Public/Model/WindAndWaterControllerBarrier.h
+++ b/Source/AGXUnrealBarrier/Public/Model/WindAndWaterControllerBarrier.h
@@ -1,0 +1,68 @@
+﻿// Copyright 2026, Algoryx Simulation AB.
+
+#pragma once
+
+// AGX Dynamics for Unreal includes.
+
+// Unreal Engine includes.
+
+// System includes.
+#include <memory>
+
+#include "WindAndWaterParametersBarrier.h"
+
+
+class FExt_WaterFlowGeneratorBarrier;
+class FDynamicWaterBarrier;
+class FWireBarrier;
+struct FShapeBarrier;
+struct FWindAndWaterControllerRef;
+struct FGeometryRef;
+
+/**
+ * Barrier between UAGX_WindAndWaterController and agxModel::WindAndWaterController.
+ * UAGX_WindAndWaterController holds an instance of WindAndWaterControllerBarrier
+ * and hidden behind the WindAndWaterControllerBarrier is a agxModel::WindAndWaterController.
+ * This allows UAGX_WindAndWaterController to interact with
+ * agxModel::WindAndWaterController without including agxModel/WindAndWaterController.h.
+ * This class handles all translation between Unreal Engine types and
+ * AGX Dynamics types, such as back and forth between FVector and agx::Vec3.
+ */
+class AGXUNREALBARRIER_API FWindAndWaterControllerBarrier
+{
+public:
+	FWindAndWaterControllerBarrier();
+	FWindAndWaterControllerBarrier(std::unique_ptr<FWindAndWaterControllerRef> Native);
+	FWindAndWaterControllerBarrier(FWindAndWaterControllerBarrier&& Other) noexcept;
+	~FWindAndWaterControllerBarrier();
+	
+	bool HasNative() const;
+	void AllocateNative();
+	FWindAndWaterControllerRef* GetNative();
+	const FWindAndWaterControllerRef* GetNative() const;
+
+	/// @return The address of the underlying AGX Dynamics object.
+	uintptr_t GetNativeAddress() const;
+
+	/// Re-assign this Barrier to the given native address. The address must be an existing AGX
+	/// Dynamics object of the correct type.
+	void SetNativeAddress(uintptr_t NativeAddress);
+	void ReleaseNative();
+	
+	FWindAndWaterParametersBarrier GetOrCreateHydrodynamicsParameters(FShapeBarrier* Shape) const;
+	FWindAndWaterParametersBarrier GetOrCreateHydrodynamicsParameters(FWireBarrier* Wire) const;
+	
+	FWindAndWaterParametersBarrier GetOrCreateAerodynamicsParameters(FShapeBarrier* Shape) const;
+	FWindAndWaterParametersBarrier GetOrCreateAerodynamicsParameters(FWireBarrier* Wire) const;
+
+	bool SetEnableAerodynamics(FShapeBarrier* Shape, bool bEnabled);
+	bool SetEnableAerodynamics(FWireBarrier* Wire, bool bEnabled);
+	bool SetEnableHydrodynamics(FShapeBarrier* Shape, bool bEnabled);
+	bool SetEnableHydrodynamics(FWireBarrier* Wire, bool bEnabled);
+	bool AddWater(const FShapeBarrier* Shape);
+	bool SetWaterWrapper(FShapeBarrier* Shape, FDynamicWaterBarrier* DynamicWater);
+	bool SetWaterFlowGenerator(FShapeBarrier* Shape, FDynamicWaterBarrier* WaterWrapper);
+
+private:
+	std::unique_ptr<FWindAndWaterControllerRef> NativeRef;
+};

--- a/Source/AGXUnrealBarrier/Public/Model/WindAndWaterParametersBarrier.h
+++ b/Source/AGXUnrealBarrier/Public/Model/WindAndWaterParametersBarrier.h
@@ -1,0 +1,54 @@
+﻿// Copyright 2026, Algoryx Simulation AB.
+
+#pragma once
+
+// AGX Dynamics for Unreal includes.
+
+// Unreal Engine includes.
+
+// System includes.
+#include <memory>
+
+enum class EWindAndWaterParametersCoefficient : uint8;
+enum class EWindAndWaterShapeTessellation : uint8;
+struct FRigidBodyBarrier;
+class FWindAndWaterControllerBarrier;
+struct FWindAndWaterParametersRef;
+
+/**
+ * Barrier between UAGX_WindAndWaterParameters and agxModel::WindAndWaterParameters. UAGX_RigidBody holds an
+ * instance of WindAndWaterParametersBarrier and hidden behind the WindAndWaterParametersBarrier is a
+ * agxModel::WindAndWaterParameters. This allows UAGX_WindAndWaterParameters to interact with
+ * agxModel::WindAndWaterParameters without including agxModel/WindAndWaterParameters.h
+ *
+ * This class handles all translation between Unreal Engine types and
+ * AGX Dynamics types, such as back and forth between FVector and agx::Vec3.
+ */
+class AGXUNREALBARRIER_API FWindAndWaterParametersBarrier
+{
+public:
+	FWindAndWaterParametersBarrier();
+	FWindAndWaterParametersBarrier(std::unique_ptr<FWindAndWaterParametersRef> Native);
+	FWindAndWaterParametersBarrier(FWindAndWaterParametersBarrier&& Other) noexcept;
+	~FWindAndWaterParametersBarrier();
+	
+	bool HasNative() const;
+	FWindAndWaterParametersRef* GetNative();
+	const FWindAndWaterParametersRef* GetNative() const;
+
+	/// @return The address of the underlying AGX Dynamics object.
+	uintptr_t GetNativeAddress() const;
+
+	/// Re-assign this Barrier to the given native address. The address must be an existing AGX
+	/// Dynamics object of the correct type.
+	void SetNativeAddress(uintptr_t NativeAddress);
+	void ReleaseNative();
+
+	void SetCoefficient(EWindAndWaterParametersCoefficient Coefficient, double Value) const;
+	void SetShapeTessellation(EWindAndWaterShapeTessellation ShapeTessellation) const;
+	static void SetHydrodynamicCoefficient(FWindAndWaterControllerBarrier* Controller, FRigidBodyBarrier* RigidBody, EWindAndWaterParametersCoefficient Coefficient, double Value);
+	static void SetAerodynamicCoefficient(FWindAndWaterControllerBarrier* Controller, FRigidBodyBarrier* RigidBody, EWindAndWaterParametersCoefficient Coefficient, double Value);
+
+protected:
+	std::unique_ptr<FWindAndWaterParametersRef> NativeRef;
+};

--- a/Source/AGXUnrealBarrier/Public/Model/WindAndWaterParametersEnums.h
+++ b/Source/AGXUnrealBarrier/Public/Model/WindAndWaterParametersEnums.h
@@ -1,0 +1,26 @@
+﻿// Copyright 2026, Algoryx Simulation AB.
+
+#pragma once
+
+UENUM(BlueprintType)
+enum class EWindAndWaterParametersCoefficient : uint8
+{
+	PRESSURE_DRAG,	
+	VISCOUS_DRAG,	
+	LIFT, 	
+	BUOYANCY 
+};
+
+/**
+ * Enum that specify the tessellation levels of native, non-mesh shapes, e.g, sphere, capsule and cylinder,
+ * that are associated with hydro collision in the context of WindAndWaterController.
+ */
+UENUM(BlueprintType)
+enum class EWindAndWaterShapeTessellation : uint8
+{
+	LOW,
+	MEDIUM,
+	HIGH,
+	ULTRA_HIGH,
+	DEFAULT_TESSELLATION = MEDIUM,
+};

--- a/Source/AGXUnrealBarrier/Public/SimulationBarrier.h
+++ b/Source/AGXUnrealBarrier/Public/SimulationBarrier.h
@@ -23,6 +23,7 @@ class FTerrainBarrier;
 class FTerrainPagerBarrier;
 class FTireBarrier;
 class FTrackBarrier;
+class FWindAndWaterControllerBarrier;
 class FWireBarrier;
 
 struct FCableBarrier;
@@ -61,7 +62,7 @@ public:
 	bool Add(FTireBarrier& Tire);
 	bool Add(FTrackBarrier& Track);
 	bool Add(FWireBarrier& Wire);
-
+	bool Add(FWindAndWaterControllerBarrier& WindAnWaterController);
 	bool Remove(FCableBarrier& Cable);
 	bool Remove(FConstraintBarrier& Constraint);
 	bool Remove(FContactMaterialBarrier& ContactMaterial);
@@ -81,7 +82,7 @@ public:
 	bool Remove(FTireBarrier& Tire);
 	bool Remove(FTrackBarrier& Track);
 	bool Remove(FWireBarrier& Wire);
-
+	bool Remove(FWindAndWaterControllerBarrier& WindAnWaterController);
 	void SetEnableCollisionGroupPair(const FName& Group1, const FName& Group2, bool CanCollide);
 
 	static void SetEnableCollision(FRigidBodyBarrier& Body1, FRigidBodyBarrier& Body2, bool Enable);

--- a/Source/AGXUnrealEditor/Private/AGXUnrealEditor.cpp
+++ b/Source/AGXUnrealEditor/Private/AGXUnrealEditor.cpp
@@ -61,6 +61,7 @@
 #include "Materials/AGX_ContactMaterial.h"
 #include "Materials/AGX_ContactMaterialCustomization.h"
 #include "Materials/AGX_ContactMaterialRegistrarActor.h"
+#include "Materials/AGX_WindAndWaterAwareShapeMaterialAssetTypeActions.h"
 #include "Materials/AGX_ContactMaterialRegistrarComponent.h"
 #include "Materials/AGX_ContactMaterialRegistrarComponentCustomization.h"
 #include "Materials/AGX_ShapeMaterialAssetTypeActions.h"
@@ -343,6 +344,8 @@ void FAGXUnrealEditorModule::RegisterAssetTypeActions()
 		AssetTools, MakeShareable(new FAGX_ShovelPropertiesActions(AgxAssetCategoryBit)));
 	RegisterAssetTypeAction(
 		AssetTools, MakeShareable(new FAGX_TerrainMaterialAssetTypeActions(AgxAssetCategoryBit)));
+	RegisterAssetTypeAction(
+		AssetTools, MakeShareable(new FAGX_WindAndWaterAwareShapeMaterialTypeActions(AgxAssetCategoryBit)));
 	RegisterAssetTypeAction(
 		AssetTools, MakeShareable(new FAGX_TerrainPropertiesActions(AgxAssetCategoryBit)));
 	RegisterAssetTypeAction(

--- a/Source/AGXUnrealEditor/Private/Materials/AGX_WindAndWaterAwareShapeMaterialAssetFactory.cpp
+++ b/Source/AGXUnrealEditor/Private/Materials/AGX_WindAndWaterAwareShapeMaterialAssetFactory.cpp
@@ -1,0 +1,24 @@
+// Copyright 2023, Algoryx Simulation AB.
+
+#include "Materials/AGX_WindAndWaterAwareShapeMaterialAssetFactory.h"
+
+// AGX Dynamics for Unreal includes.
+
+#include "Model/AGX_WindAndWaterAwareShapeMaterial.h"
+
+UAGX_WindAndWaterAwareShapeMaterialFactory::UAGX_WindAndWaterAwareShapeMaterialFactory(const class FObjectInitializer& OBJ)
+	: Super(OBJ)
+{
+	SupportedClass = UAGX_WindAndWaterAwareShapeMaterial::StaticClass();
+	bEditAfterNew = true;
+	bCreateNew = true;
+}
+
+UObject* UAGX_WindAndWaterAwareShapeMaterialFactory::FactoryCreateNew(
+	UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context,
+	FFeedbackContext* Warn)
+{
+	check(Class->IsChildOf(UAGX_WindAndWaterAwareShapeMaterial::StaticClass()));
+	return NewObject<UAGX_WindAndWaterAwareShapeMaterial>(
+		InParent, Class, Name, Flags | RF_Transactional, Context);
+}

--- a/Source/AGXUnrealEditor/Private/Materials/AGX_WindAndWaterAwareShapeMaterialAssetTypeActions.cpp
+++ b/Source/AGXUnrealEditor/Private/Materials/AGX_WindAndWaterAwareShapeMaterialAssetTypeActions.cpp
@@ -1,0 +1,49 @@
+// Copyright 2023, Algoryx Simulation AB.
+
+#include "Materials/AGX_WindAndWaterAwareShapeMaterialAssetTypeActions.h"
+
+#include "Model/AGX_WindAndWaterAwareShapeMaterial.h"
+
+#define LOCTEXT_NAMESPACE "FAGX_WindAndWaterAwareShapeMaterialTypeActions"
+
+FAGX_WindAndWaterAwareShapeMaterialTypeActions::FAGX_WindAndWaterAwareShapeMaterialTypeActions(
+	EAssetTypeCategories::Type InAssetCategory)
+	: AssetCategory(InAssetCategory)
+{
+}
+
+FText FAGX_WindAndWaterAwareShapeMaterialTypeActions::GetName() const
+{
+	return LOCTEXT("AssetName", "AGX Wind And Water Aware Shape Material");
+}
+
+uint32 FAGX_WindAndWaterAwareShapeMaterialTypeActions::GetCategories()
+{
+	return AssetCategory;
+}
+
+const TArray<FText>& FAGX_WindAndWaterAwareShapeMaterialTypeActions::GetSubMenus() const
+{
+	static const TArray<FText> SubMenus {
+		LOCTEXT("WindAndWaterSubMenu", "Hydro&Aero"),
+	};
+
+	return SubMenus;
+}
+
+FColor FAGX_WindAndWaterAwareShapeMaterialTypeActions::GetTypeColor() const
+{
+	return FColor(255, 115, 0);
+}
+
+FText FAGX_WindAndWaterAwareShapeMaterialTypeActions::GetAssetDescription(const FAssetData& AssetData) const
+{
+	return LOCTEXT("AssetDescription", "Defines bulk and surface properties of AGX Shapes.");
+}
+
+UClass* FAGX_WindAndWaterAwareShapeMaterialTypeActions::GetSupportedClass() const
+{
+	return UAGX_WindAndWaterAwareShapeMaterial::StaticClass();
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/AGXUnrealEditor/Public/Materials/AGX_WindAndWaterAwareShapeMaterialAssetFactory.h
+++ b/Source/AGXUnrealEditor/Public/Materials/AGX_WindAndWaterAwareShapeMaterialAssetFactory.h
@@ -1,0 +1,31 @@
+// Copyright 2023, Algoryx Simulation AB.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Factories/Factory.h"
+#include "AGX_WindAndWaterAwareShapeMaterialAssetFactory.generated.h"
+
+/**
+ * Asset Factory for UAGX_WindAndWaterAwareShapeMaterial, making it possible to create asset objects in the
+ * Editor.
+ */
+UCLASS()
+class AGXUNREALEDITOR_API UAGX_WindAndWaterAwareShapeMaterialFactory : public UFactory
+{
+	GENERATED_BODY()
+
+public:
+	UAGX_WindAndWaterAwareShapeMaterialFactory(const class FObjectInitializer& OBJ);
+
+protected:
+	virtual bool IsMacroFactory() const
+	{
+		return false;
+	}
+
+public:
+	virtual UObject* FactoryCreateNew(
+		UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context,
+		FFeedbackContext* Warn) override;
+};

--- a/Source/AGXUnrealEditor/Public/Materials/AGX_WindAndWaterAwareShapeMaterialAssetTypeActions.h
+++ b/Source/AGXUnrealEditor/Public/Materials/AGX_WindAndWaterAwareShapeMaterialAssetTypeActions.h
@@ -1,0 +1,33 @@
+// Copyright 2023, Algoryx Simulation AB.
+
+#pragma once
+
+
+// Unreal Engine includes.
+#include "AssetTypeActions_Base.h"
+#include "AssetTypeCategories.h"
+#include "CoreMinimal.h"
+
+/**
+ * Asset Type Actions for UAGX_WindAndWaterAwareShapeMaterial, customizing its appearance in the Editor menus
+ * and browsers.
+ */
+class AGXUNREALEDITOR_API FAGX_WindAndWaterAwareShapeMaterialTypeActions : public FAssetTypeActions_Base
+{
+public:
+	FAGX_WindAndWaterAwareShapeMaterialTypeActions(EAssetTypeCategories::Type InAssetCategory);
+
+	FText GetName() const override;
+
+	uint32 GetCategories() override;
+	const TArray<FText>& GetSubMenus() const;
+
+	FColor GetTypeColor() const override;
+
+	FText GetAssetDescription(const FAssetData& AssetData) const override;
+
+	UClass* GetSupportedClass() const override;
+
+private:
+	EAssetTypeCategories::Type AssetCategory;
+};


### PR DESCRIPTION
## Add support for Hydro/Aero module

This PR integrates Hydrodynamics/Aerodynamics module into AGXUnreal.

### New classes

**AGXUnreal (gameplay layer)**
- `UAGX_DynamicWaterComponent` — Scene component representing a dynamic water body. Exposes water surface height, density, and velocity queries, and wraps a native `agxModel::DynamicWater` via `FDynamicWaterBarrier`.
- `UAGX_WindAndWaterControllerSubsystemBase` — Abstract `UGameInstanceSubsystem` that holds the `agxModel::WindAndWaterController` as a singleton. Provides APIs to register water geometries, enable/disable aero- and hydrodynamics on shapes and wires, and update per-shape wind/water parameters at runtime.
- `UAGX_WindAndWaterAwareShapeMaterial` — Extends `UAGX_ShapeMaterial` with `FAGX_Ext_WindAndWaterParameters` structs for both hydrodynamic and aerodynamic coefficients (pressure drag, viscous drag, lift, buoyancy, shape tessellation). Adds a `bIsWaterGeometry` flag to mark a shape as water. If this special material is not used, normal material will not interact with water.

**AGXUnrealBarrier (AGX Dynamics bridge layer)**
- `FWindAndWaterControllerBarrier` — Barrier wrapping `agxModel::WindAndWaterController`. Provides methods to add water geometries, set/get hydro and aero parameters on shapes and wires, and manage native lifecycle.
- `FWindAndWaterParametersBarrier` — Barrier for reading and writing individual wind/water parameter coefficients on a shape or wire.
- `FDynamicWaterBarrier` — Barrier for `agxModel::DynamicWater`, exposing surface height, density, and flow velocity queries.
- `EWindAndWaterParametersCoefficient` / `EWindAndWaterShapeTessellation` — Blueprint-exposed enums for coefficient type and tessellation level of non-mesh shapes (sphere, capsule, cylinder).

**AGXUnrealEditor**
- `UAGX_WindAndWaterAwareShapeMaterialAssetFactory` and `AGX_WindAndWaterAwareShapeMaterialAssetTypeActions` — Editor factory and type actions for creating `UAGX_WindAndWaterAwareShapeMaterial` assets from the Content Browser.

### Other changes
- `AGX_ShapeComponent`: registers shapes with the `WindAndWaterController` subsystem on begin play when a `WindAndWaterAwareShapeMaterial` is assigned. _Ideally ShapeComponent and WaterModule should be decoupled._
- `AGX_ShapeMaterial`: minor fix to `CopyShapeMaterialProperties` for the extension of new material type.
- `SimulationBarrier`: exposes the native simulation reference needed to add the `WindAndWaterController` to the AGX simulation.
- `AGXBarrierFactories`: adds factory support for the new barrier types.
- `AGXRefs.h` / `AGXTypeConversions.h`: adds native ref structs and type conversion helpers for the new AGX model types.