### PR TITLE
fix/editor-icon-loads-during-cook

### DIFF
--- a/Source/AGXUnreal/Private/CollisionGroups/AGX_CollisionGroupDisablerSpriteComponent.cpp
+++ b/Source/AGXUnreal/Private/CollisionGroups/AGX_CollisionGroupDisablerSpriteComponent.cpp
@@ -18,7 +18,7 @@ void UAGX_CollisionGroupDisablerSpriteComponent::OnRegister()
 {
 	Super::OnRegister();
 #if WITH_EDITORONLY_DATA
-	if (SpriteComponent)
+	if (GIsEditor && !IsRunningCommandlet() && SpriteComponent)
 	{
 		FName NewName = MakeUniqueObjectName(
 			SpriteComponent->GetOuter(), SpriteComponent->GetClass(),

--- a/Source/AGXUnreal/Private/Materials/AGX_ContactMaterialRegistrarSpriteComponent.cpp
+++ b/Source/AGXUnreal/Private/Materials/AGX_ContactMaterialRegistrarSpriteComponent.cpp
@@ -18,7 +18,7 @@ void UAGX_ContactMaterialRegistrarSpriteComponent::OnRegister()
 {
 	Super::OnRegister();
 #if WITH_EDITORONLY_DATA
-	if (SpriteComponent)
+	if (GIsEditor && !IsRunningCommandlet() && SpriteComponent)
 	{
 		FName NewName = MakeUniqueObjectName(
 			SpriteComponent->GetOuter(), SpriteComponent->GetClass(),

--- a/Source/AGXUnreal/Private/Sensors/AGX_SensorEnvironmentSpriteComponent.cpp
+++ b/Source/AGXUnreal/Private/Sensors/AGX_SensorEnvironmentSpriteComponent.cpp
@@ -18,7 +18,7 @@ void UAGX_SensorEnvironmentSpriteComponent::OnRegister()
 {
 	Super::OnRegister();
 #if WITH_EDITORONLY_DATA
-	if (SpriteComponent)
+	if (GIsEditor && !IsRunningCommandlet() && SpriteComponent)
 	{
 		FName NewName = MakeUniqueObjectName(
 			SpriteComponent->GetOuter(), SpriteComponent->GetClass(), TEXT("SensorEnvironmentIcon"));

--- a/Source/AGXUnreal/Private/Terrain/AGX_TerrainSpriteComponent.cpp
+++ b/Source/AGXUnreal/Private/Terrain/AGX_TerrainSpriteComponent.cpp
@@ -18,7 +18,7 @@ void UAGX_TerrainSpriteComponent::OnRegister()
 {
 	Super::OnRegister();
 #if WITH_EDITORONLY_DATA
-	if (SpriteComponent)
+	if (GIsEditor && !IsRunningCommandlet() && SpriteComponent)
 	{
 		FName NewName = MakeUniqueObjectName(
 			SpriteComponent->GetOuter(), SpriteComponent->GetClass(), TEXT("TerrainIcon"));

--- a/Source/AGXUnreal/Private/Wire/AGX_WireComponent.cpp
+++ b/Source/AGXUnreal/Private/Wire/AGX_WireComponent.cpp
@@ -1877,7 +1877,7 @@ void UAGX_WireComponent::OnRegister()
 	AGX_WireComponent_helpers::SetLocalScope(*this);
 
 #if WITH_EDITORONLY_DATA
-	if (SpriteComponent)
+	if (GIsEditor && !IsRunningCommandlet() && SpriteComponent)
 	{
 		FName NewName = MakeUniqueObjectName(
 			SpriteComponent->GetOuter(), SpriteComponent->GetClass(), TEXT("WireIcon"));

--- a/Source/AGXUnreal/Private/Wire/AGX_WireWinchComponent.cpp
+++ b/Source/AGXUnreal/Private/Wire/AGX_WireWinchComponent.cpp
@@ -240,7 +240,7 @@ void UAGX_WireWinchComponent::OnRegister()
 	WireWinch.BodyAttachment.SetLocalScope(GetTypedOuter<AActor>());
 
 #if WITH_EDITORONLY_DATA
-	if (SpriteComponent)
+	if (GIsEditor && !IsRunningCommandlet() && SpriteComponent)
 	{
 		FName NewName = MakeUniqueObjectName(
 			SpriteComponent->GetOuter(), SpriteComponent->GetClass(), TEXT("WireWinchIcon"));


### PR DESCRIPTION
## Summary

This prevents AGX editor visualization sprite icons from being dynamically loaded during cook commandlets.

Several runtime sprite components set editor-only billboard icons in `OnRegister()` behind `WITH_EDITORONLY_DATA`. During cook, editor-only data can still be compiled in, so these `LoadObject<UTexture2D>` calls may execute while commandlets are loading packages. That causes cook warnings about `/AGXUnreal/Editor/Icons/...` packages being unexpectedly loaded.

The icon setup now also checks `!IsRunningCommandlet()` before loading editor visualization textures.

## Changed

- Guarded editor sprite icon loads in:
  - collision group disabler sprite component
  - contact material registrar sprite component
  - sensor environment sprite component
  - terrain sprite component
  - wire component
  - wire winch component