### PR TITLE
fix/include-shaders

### DIFF
--- a/Config/FilterPlugin.ini
+++ b/Config/FilterPlugin.ini
@@ -3,6 +3,7 @@
 ; may include "...", "*", and "?" wildcards to match directories, files, and individual characters respectively.
 license/README.md
 Config/
+Shaders/
 ;
 ; Examples:
 ;    /README.txt


### PR DESCRIPTION
Include the Shader directory in FilterPlugin.ini

After the 2.3.0 release we got bug reports about the Shaders directory being missing. This is surprising since this folder has been present since 2.0.0 and I don't think anything has changed since then. So unclear why we get these problems now. Still, listing it in FilterPlugin.ini seems like the right thing to do.